### PR TITLE
Switch query library source to ted-open-data-examples

### DIFF
--- a/scripts/extract-query-parameters.js
+++ b/scripts/extract-query-parameters.js
@@ -2,7 +2,7 @@
  * Extract query parameters from the remote SPARQL query library and generate
  * templates with {{placeholder}} syntax for unambiguous value injection.
  *
- * Downloads each .sparql file referenced in index.yaml, scans for xsd:date
+ * Downloads each .sparql file referenced in web-library.yaml, scans for xsd:date
  * typed literals, replaces them with named placeholders, and outputs
  * src/assets/query-parameters.json containing:
  *   - template: the query text with {{placeholders}} instead of literal dates
@@ -21,11 +21,11 @@
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
 
-const REMOTE_QUERIES_URL = 'https://raw.githubusercontent.com/OP-TED/ted-rdf-docs/main/docs/antora/modules/samples/queries/';
+const REMOTE_QUERIES_URL = 'https://raw.githubusercontent.com/OP-TED/ted-open-data-examples/main/';
 const OUTPUT_PATH = 'src/assets/query-parameters.json';
 
 /**
- * Minimal YAML parser for the index.yaml structure.
+ * Minimal YAML parser for the web-library.yaml structure.
  */
 function parseIndexYaml(text) {
   const queries = [];
@@ -176,10 +176,10 @@ function humanizePlaceholder(name) {
 }
 
 async function main() {
-  console.log('Fetching index.yaml...');
-  const indexResponse = await fetch(`${REMOTE_QUERIES_URL}index.yaml`);
+  console.log('Fetching web-library.yaml...');
+  const indexResponse = await fetch(`${REMOTE_QUERIES_URL}web-library.yaml`);
   if (!indexResponse.ok) {
-    throw new Error(`Failed to fetch index.yaml: HTTP ${indexResponse.status}`);
+    throw new Error(`Failed to fetch web-library.yaml: HTTP ${indexResponse.status}`);
   }
   const indexText = await indexResponse.text();
   const data = parseIndexYaml(indexText);
@@ -195,7 +195,7 @@ async function main() {
   let skippedCount = 0;
 
   for (const query of data.queries) {
-    const filename = query.sparql;
+    const filename = query.sparql.split('/').pop();
 
     // Skip if already declared
     if (existing[filename]) {
@@ -203,8 +203,8 @@ async function main() {
       continue;
     }
 
-    // Fetch the .sparql file
-    const url = `${REMOTE_QUERIES_URL}${filename}`;
+    // Fetch the .sparql file (use full path from manifest for the URL)
+    const url = `${REMOTE_QUERIES_URL}${query.sparql}`;
     const response = await fetch(url);
     if (!response.ok) {
       console.warn(`  WARNING: Failed to fetch ${filename}: HTTP ${response.status}`);

--- a/src/js/QueryLibrary.js
+++ b/src/js/QueryLibrary.js
@@ -169,8 +169,8 @@ export class QueryLibrary {
       // All text is set via textContent and all identifiers are safely
       // slugified, so a query title or category name containing quotes,
       // angle brackets or HTML entities cannot escape the markup. The
-      // source YAML is trusted (OP-TED/ted-rdf-docs), but defence in depth
-      // is cheap here and prevents future supply-chain or typo issues.
+      // source YAML is trusted (OP-TED/ted-open-data-examples), but defence
+      // in depth is cheap here and prevents future supply-chain or typo issues.
       let categoryCounter = 0;
       categories.forEach((queries, category) => {
         const categoryId = `category-${categoryCounter++}`;

--- a/src/js/QueryLibrary.js
+++ b/src/js/QueryLibrary.js
@@ -149,7 +149,7 @@ export class QueryLibrary {
       // Fetch the YAML file containing the queries. Check
       // response.ok explicitly — otherwise a 404 HTML body flows
       // into yaml.load() and throws an opaque parse error.
-      const response = await fetch(`${this.remoteQueriesUrl}index.yaml`);
+      const response = await fetch(`${this.remoteQueriesUrl}web-library.yaml`);
       if (!response.ok) {
         throw new Error(`HTTP error. Status: ${response.status}`);
       }
@@ -525,7 +525,8 @@ export class QueryLibrary {
    * @private
    */
   _renderParameterForm(sparqlFilename) {
-    const entry = this.queryParametersData?.[sparqlFilename];
+    const basename = sparqlFilename.split('/').pop();
+    const entry = this.queryParametersData?.[basename];
     this.currentParams = entry?.parameters || [];
     this.currentTemplate = entry?.template || null;
 

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -30,7 +30,7 @@ import { SearchPanel } from './SearchPanel.js';
 import { setController } from './TermRenderer.js';
 
 const SPARQL_ENDPOINT = 'https://publications.europa.eu/webapi/rdf/sparql';
-const REMOTE_QUERIES_URL = 'https://raw.githubusercontent.com/OP-TED/ted-rdf-docs/main/docs/antora/modules/samples/queries/';
+const REMOTE_QUERIES_URL = 'https://raw.githubusercontent.com/OP-TED/ted-open-data-examples/main/';
 
 // Reset scroll on page load (browsers may restore previous scroll position).
 if ('scrollRestoration' in history) history.scrollRestoration = 'manual';


### PR DESCRIPTION
## Summary
Resolves https://github.com/OP-TED/ted-open-data/issues/75

The query library runtime fetcher and the parameter-extraction script now read from the dedicated `OP-TED/ted-open-data-examples` repository instead of the `ted-rdf-docs` Antora module.

- `REMOTE_QUERIES_URL` points to the new repo root (main branch)
- Manifest filename changed from `index.yaml` to `web-library.yaml`
- Parameter form lookup uses the basename of the sparql path to match `query-parameters.json` keys (bare filenames), since the new manifest uses relative paths (e.g. `queries/notices-per-day.sparql`)
- `extract-query-parameters.js` uses the full path for fetching but the basename for the JSON key, keeping the output format stable

## Testing
- Rebased cleanly on latest `develop`, no conflicts
- Full test suite passing (321/321)
- `node scripts/extract-query-parameters.js` run live against the new manifest — matched all 36 existing entries by basename, produced identical output
- Verified `web-library.yaml` and referenced `.sparql` files resolve correctly against the live `ted-open-data-examples` repo
- Manually tested the query library in the running app — confirmed working