### PR TITLE
Connect your app: sharing the query as a request (rework of #113)

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
                                 When you find what you need, take it home. Look for the
                                 <strong style="white-space: nowrap;"><i class="bi bi-download"></i>&nbsp;Download</strong>
                                 button to get the results in the format that fits your work. Look for the
-                                <strong style="white-space: nowrap;"><i class="bi bi-clipboard"></i>&nbsp;Copy Query</strong>
+                                <strong style="white-space: nowrap;"><i class="bi bi-plug"></i>&nbsp;Connect your app</strong>
                                 button to call the same query from your own application and keep it up
                                 to date with live data all the time.
                             </p>
@@ -440,7 +440,7 @@
 
         <!-- Query Results (SELECT lane) -->
         <div class="tab-pane w-100 fade" id="query-results" role="tabpanel" aria-labelledby="query-results-tab">
-            <!-- Slim results toolbar — hint on the left, Copy URL +
+            <!-- Slim results toolbar — hint on the left, Connect your app +
                  Download as… on the right. Mirrors the visual weight
                  of the breadcrumb bar on the graph lane: flat, a
                  single thin bottom border, no fill. Toggled via
@@ -459,17 +459,10 @@
                     <p class="small text-muted mb-0" id="query-execution-time" style="display: none;">Execution time: <span id="query-execution-time-value"></span></p>
                 </div>
                 <div class="results-toolbar-actions">
-                    <div class="dropdown d-inline-block me-2">
-                        <button id="copy-url-button" class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
-                                data-bs-toggle="dropdown" aria-expanded="false">
-                            <i class="bi bi-clipboard"></i> Copy Query
-                        </button>
-                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="copy-url-button">
-                            <li><a class="dropdown-item" href="#" data-share-type="query-link"><i class="bi bi-link-45deg me-2"></i>Query link</a></li>
-                            <li><a class="dropdown-item" href="#" data-share-type="sparql-query"><i class="bi bi-code-slash me-2"></i>SPARQL query</a></li>
-                            <li><a class="dropdown-item" href="#" data-share-type="curl-command"><i class="bi bi-terminal me-2"></i>cURL command</a></li>
-                        </ul>
-                    </div>
+                    <button id="connect-button" class="btn btn-sm btn-primary" type="button"
+                            aria-expanded="false" aria-haspopup="dialog">
+                        <i class="bi bi-plug"></i> Connect your app
+                    </button>
                     <div class="dropdown d-inline-block">
                         <button id="download-as-button" class="btn btn-sm btn-outline-primary dropdown-toggle" type="button"
                                 data-bs-toggle="dropdown" aria-expanded="false">
@@ -483,7 +476,11 @@
                             <li><a class="dropdown-item" href="#" data-download-format="application/sparql-results+xml">XML</a></li>
                         </ul>
                     </div>
-                    <div id="results-view-toggle" class="d-none d-flex align-items-center ms-2">
+                    <!-- Taking the data away, and looking at it here, are two
+                         different jobs; the rule says so. Hidden with the
+                         toggle, which only appears for chartable results. -->
+                    <div id="results-view-toggle" class="d-none d-flex align-items-center">
+                        <div class="vr button-row-divider"></div>
                         <div class="btn-group btn-group-sm" role="group" aria-label="Switch between table and chart view">
                             <input type="radio" class="btn-check" name="results-view" id="results-view-table" value="table" checked>
                             <label class="btn btn-outline-secondary px-4" for="results-view-table">
@@ -767,7 +764,7 @@
                             <li>To test your query use the <b>Run Query</b> button.</li>
                             <li>SELECT and ASK results are displayed in the <b>Query Results</b> tab as a table — or as an interactive chart (bar, line, pie, scatter) via the <b>Table / Chart</b> toggle when the results are chartable.</li>
                             <li>CONSTRUCT and DESCRIBE results are displayed in the <b>Query Results</b> tab as an RDF graph (the same tree/turtle/backlinks view used by notice lookup).</li>
-                            <li>For SELECT queries you can get a URL that runs the query directly by clicking on the <b>Copy URL</b> button.<br/>
+                            <li>For SELECT queries, the <b>Connect your app</b> button gives you the link, and the commands, to run the same query from your own tools.<br/>
                                 You can use this URL to run your query and retrieve live results directly into <b>Excel</b>, <b>Power BI</b>, or any application that can get data from the web.</li>
                             <li>To download a copy of the data retrieved by a SELECT query, use the <b>Download</b> button.</li>
                         </ul>
@@ -989,6 +986,82 @@
                 </div>
             </div>
         </div>
+    </div>
+
+    <!-- Connect dialog — how to run this query from outside the site.
+         The format chosen at the top governs every snippet below it, so
+         what you copy always matches what you picked. Filled at open time
+         by QueryResults; the lists of formats differ per lane. -->
+    <div id="connect-panel">
+                <div class="connect-body">
+                    <div class="connect-primary">
+                        <p>
+                            Paste this link into Excel, Power BI, or any tool that reads data from
+                            the web. It re-runs your query and returns fresh data every time.
+                        </p>
+                        <!-- A split button: copy on the left, the format it will
+                             return on the right. One click for the act, and the
+                             choice visible without opening anything. -->
+                        <div class="btn-group">
+                            <button class="btn btn-sm btn-primary connect-copy" type="button" data-connect-copy="link">
+                                <i class="bi bi-clipboard"></i> Copy link
+                            </button>
+                            <button class="btn btn-sm btn-primary dropdown-toggle connect-format-toggle" type="button"
+                                    data-bs-toggle="dropdown" aria-expanded="false"
+                                    aria-label="Choose the format the link returns">
+                                <span data-connect-format-name="link">JSON</span>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end" data-connect-format-menu="link"></ul>
+                        </div>
+                    </div>
+
+                    <hr class="connect-rule">
+
+                    <div class="connect-secondary">
+                        <p class="mb-2">
+                            If you want to run this in a terminal, or in an app that speaks
+                            SPARQL, use one of the buttons below.
+                        </p>
+                        <div class="connect-commands">
+                            <!-- A menu of formats, each of which copies. The
+                                 format is part of the act rather than a setting
+                                 carried on the button. -->
+                            <div class="dropdown">
+                                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
+                                        data-bs-toggle="dropdown" aria-expanded="false"
+                                        title="Copy a cURL command — macOS, Linux">
+                                    <i class="bi bi-clipboard"></i> cURL
+                                </button>
+                                <ul class="dropdown-menu" data-connect-copy-menu="curl"></ul>
+                            </div>
+                            <div class="dropdown">
+                                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
+                                        data-bs-toggle="dropdown" aria-expanded="false"
+                                        title="Copy a wget command — Linux">
+                                    <i class="bi bi-clipboard"></i> wget
+                                </button>
+                                <ul class="dropdown-menu" data-connect-copy-menu="wget"></ul>
+                            </div>
+                            <div class="dropdown">
+                                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
+                                        data-bs-toggle="dropdown" aria-expanded="false"
+                                        title="Copy a PowerShell command — Windows">
+                                    <i class="bi bi-clipboard"></i> PowerShell
+                                </button>
+                                <ul class="dropdown-menu" data-connect-copy-menu="powershell"></ul>
+                            </div>
+                            <!-- The commands end here. What follows is the query
+                                 itself, which is not one — and has no format:
+                                 the text is the same whatever the endpoint is
+                                 asked to return. -->
+                            <div class="vr button-row-divider"></div>
+                            <button class="btn btn-sm btn-outline-secondary connect-copy" type="button"
+                                    data-connect-copy="sparql" title="Copy the SPARQL query, to put into your own code">
+                                <i class="bi bi-clipboard"></i> SPARQL
+                            </button>
+                        </div>
+                    </div>
+                </div>
     </div>
 
     <!-- Toast Container — one shared toast reused by both Copy URL

--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
                                 When you find what you need, take it home. Look for the
                                 <strong style="white-space: nowrap;"><i class="bi bi-download"></i>&nbsp;Download</strong>
                                 button to get the results in the format that fits your work. Look for the
-                                <strong style="white-space: nowrap;"><i class="bi bi-rocket-takeoff"></i>&nbsp;Copy endpoint URL</strong>
+                                <strong style="white-space: nowrap;"><i class="bi bi-clipboard"></i>&nbsp;Copy Query</strong>
                                 button to call the same query from your own application and keep it up
                                 to date with live data all the time.
                             </p>
@@ -459,7 +459,17 @@
                     <p class="small text-muted mb-0" id="query-execution-time" style="display: none;">Execution time: <span id="query-execution-time-value"></span></p>
                 </div>
                 <div class="results-toolbar-actions">
-                    <button type="button" id="copy-url-button" class="btn btn-sm btn-outline-secondary me-2"><i class="bi bi-rocket-takeoff"></i> Copy endpoint URL</button>
+                    <div class="dropdown d-inline-block me-2">
+                        <button id="copy-url-button" class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
+                                data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-clipboard"></i> Copy Query
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="copy-url-button">
+                            <li><a class="dropdown-item" href="#" data-share-type="query-link"><i class="bi bi-link-45deg me-2"></i>Query link</a></li>
+                            <li><a class="dropdown-item" href="#" data-share-type="sparql-query"><i class="bi bi-code-slash me-2"></i>SPARQL query</a></li>
+                            <li><a class="dropdown-item" href="#" data-share-type="curl-command"><i class="bi bi-terminal me-2"></i>cURL command</a></li>
+                        </ul>
+                    </div>
                     <div class="dropdown d-inline-block">
                         <button id="download-as-button" class="btn btn-sm btn-outline-primary dropdown-toggle" type="button"
                                 data-bs-toggle="dropdown" aria-expanded="false">

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1117,7 +1117,7 @@ main {
    action buttons (both lanes). */
 #data-share-btn i.bi,
 #data-download-btn i.bi,
-#copy-url-button i.bi,
+#connect-button i.bi,
 #download-as-button i.bi {
   margin-right: 0.3rem;
 }

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -312,16 +312,20 @@ main {
 }
 
 /* Buttons */
-.btn-primary {
-    background-color: var(--ted-primary);
-    border-color: var(--ted-primary);
-}
 
-.btn-primary:hover,
-.btn-primary:focus,
-.btn-primary:active {
-    background-color: var(--ted-green-dark); /* Darker shade of TED green */
-    border-color: var(--ted-green-dark);
+/* Set through Bootstrap's own variables rather than by overriding the
+   properties: 5.3 draws every state from --bs-btn-*, so a rule that sets
+   background-color reaches the resting and hover states but loses the
+   pressed one, which stayed Bootstrap blue. */
+.btn-primary {
+    --bs-btn-bg: var(--ted-primary);
+    --bs-btn-border-color: var(--ted-primary);
+    --bs-btn-hover-bg: var(--ted-green-dark);
+    --bs-btn-hover-border-color: var(--ted-green-dark);
+    --bs-btn-active-bg: var(--ted-green-dark);
+    --bs-btn-active-border-color: var(--ted-green-dark);
+    --bs-btn-disabled-bg: var(--ted-primary);
+    --bs-btn-disabled-border-color: var(--ted-primary);
 }
 
 /* Outline variant of the primary button — used by the carousel's
@@ -330,16 +334,12 @@ main {
    2-4; on hover it fills in with the same TED green as those CTAs
    for visual consistency at the moment of interaction. */
 .btn-outline-primary {
-    color: var(--ted-primary);
-    border-color: var(--ted-primary);
-}
-
-.btn-outline-primary:hover,
-.btn-outline-primary:focus,
-.btn-outline-primary:active {
-    background-color: var(--ted-primary);
-    border-color: var(--ted-primary);
-    color: #fff;
+    --bs-btn-color: var(--ted-primary);
+    --bs-btn-border-color: var(--ted-primary);
+    --bs-btn-hover-bg: var(--ted-primary);
+    --bs-btn-hover-border-color: var(--ted-primary);
+    --bs-btn-active-bg: var(--ted-primary);
+    --bs-btn-active-border-color: var(--ted-primary);
 }
 
 .btn-primary:disabled {
@@ -1080,9 +1080,13 @@ main {
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.results-toolbar-actions {
+/* One gap, applied by the container, so every item in the row — including
+   the rule — is spaced alike rather than by its own margin. */
+.results-toolbar-actions,
+#results-view-toggle {
   display: flex;
   flex-shrink: 0;
+  gap: 0.5rem;
 }
 /* A little vertical breathing room on the toolbar buttons — keep
    them noticeably slimmer than a default btn-sm (which is 31px tall
@@ -1090,6 +1094,15 @@ main {
    feel unhurried. */
 .results-toolbar .btn {
   padding: 0.35rem 1rem;
+}
+
+/* Shorter than the buttons it sits between, so it reads as a separator
+   rather than as another edge in the row. Used by both button rows that
+   hold two kinds of thing. */
+.button-row-divider {
+  align-self: center;
+  height: 1.5rem;
+  opacity: 0.25;
 }
 
 /* Graph-lane buttons get the same horizontal padding so both lanes
@@ -1836,4 +1849,103 @@ main {
    as well, which does not fit Bootstrap's default 200px. */
 .breadcrumb-tooltip .tooltip-inner {
   max-width: 300px;
+}
+
+/* ── Connect panel ── */
+
+/* The panel's markup lives in the page and is handed to Bootstrap as the
+   popover's content, so between shows it sits wherever it was declared. It is
+   hidden by where it is rather than by a class the code has to remember to
+   toggle: visible only once the popover has taken it. */
+#connect-panel {
+  display: none;
+}
+
+.connect-popover #connect-panel {
+  display: block;
+}
+
+/* Bootstrap caps a popover at 276px, which is a column of wrapped words for
+   this content. Wide enough here for the sentence to read as a sentence. */
+.connect-popover {
+  --bs-popover-max-width: 540px;
+}
+
+/* Lifted off the results. A 1px border alone leaves the table rows behind it
+   reading almost as though they were inside it. */
+.connect-popover {
+  box-shadow: 0 0.5rem 1.5rem rgba(0, 0, 0, 0.175);
+}
+
+.connect-popover .popover-body {
+  padding: 1.5rem;
+}
+
+/* Bootstrap fills an outline button in on hover and while its menu is open.
+   Beside a solid green Connect button, a filled green Download reads as a
+   second primary — so it never fills. A faint tint answers the pointer
+   instead, and the open menu below it says when it is open. */
+#download-as-button {
+  --bs-btn-hover-bg: transparent;
+  --bs-btn-hover-color: var(--ted-primary);
+  --bs-btn-hover-border-color: var(--ted-primary);
+  --bs-btn-active-bg: transparent;
+  --bs-btn-active-color: var(--ted-primary);
+  --bs-btn-active-border-color: var(--ted-primary);
+}
+
+/* Pressed while its own panel is open: the invitation has moved inside the
+   panel, so this recedes — but stays solid, or it would be indistinguishable
+   from the outlined Download button beside it. */
+#connect-button.connect-open {
+  --bs-btn-bg: var(--ted-green-dark);
+  --bs-btn-border-color: var(--ted-green-dark);
+  --bs-btn-hover-bg: var(--ted-green-dark);
+  --bs-btn-hover-border-color: var(--ted-green-dark);
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* The act first, the explanation under it. Someone who already knows what
+   they came for should not have to read a paragraph to find the button. */
+.connect-primary {
+  text-align: left;
+}
+
+/* The same padding the toolbar gives its own buttons. Without it this one
+   takes Bootstrap's btn-sm default and looks pinched beside the button that
+   opened the panel. */
+.connect-primary .btn {
+  padding: 0.35rem 1rem;
+}
+
+.connect-primary p {
+  margin: 0 0 1rem;
+}
+
+/* The half of the split button that names the format. Separated by a hairline
+   so the two halves read as two things, not one long label. */
+.connect-format-toggle {
+  border-left: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+/* One thing above the rule — the answer — and, below it, conveniences that
+   are not what this dialog is for. Quiet: smaller, and asking for no
+   attention until somebody goes looking for them. */
+/* A wide gap above, a narrow one below: the button belongs to the paragraph
+   it answers, and the rule belongs to what follows it. Below the rule, the
+   same 0.5rem the paragraph there leaves above its own buttons. */
+.connect-rule {
+  margin: 3rem 0 0.5rem;
+}
+
+.connect-secondary {
+  font-size: 0.85rem;
+  color: var(--ted-text-muted);
+  text-align: left;
+}
+
+.connect-commands {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }

--- a/src/js/QueryEditor.js
+++ b/src/js/QueryEditor.js
@@ -511,16 +511,16 @@ export class QueryEditor {
     this.resultsErrorMessage.textContent = friendly;
     if (action?.kind === 'copy-select-url') {
       // Append a space + inline link + period to the friendly
-      // sentence. Clicking the link calls the existing Copy URL
-      // handler on QueryResults so the user gets the same toast
-      // and the same JSON-format URL we offer from the toolbar.
+      // sentence. Clicking the link calls the Copy Query handler
+      // on QueryResults so the user gets the same toast and the
+      // same JSON-format URL we offer from the toolbar.
       this.resultsErrorMessage.appendChild(document.createTextNode(' You can still '));
       const link = document.createElement('a');
       link.href = '#';
       link.textContent = action.label;
       link.addEventListener('click', (e) => {
         e.preventDefault();
-        this.queryResults?.onCopyUrl();
+        this.queryResults?.onShare('query-link');
       });
       this.resultsErrorMessage.appendChild(link);
       this.resultsErrorMessage.appendChild(document.createTextNode(' to use the query from a tool that can handle long-running requests.'));

--- a/src/js/QueryEditor.js
+++ b/src/js/QueryEditor.js
@@ -241,7 +241,7 @@ export class QueryEditor {
   /**
    * Initialize event listeners.
    * Sets up event listeners for form submission and the stop button.
-   * The Copy URL button is owned by `QueryResults`, which binds its
+   * The Connect your app button is owned by `QueryResults`, which binds its
    * own handler — we no longer double-bind here.
    */
   initEventListeners() {
@@ -510,17 +510,18 @@ export class QueryEditor {
     // re-rendering.
     this.resultsErrorMessage.textContent = friendly;
     if (action?.kind === 'copy-select-url') {
-      // Append a space + inline link + period to the friendly
-      // sentence. Clicking the link calls the Copy Query handler
-      // on QueryResults so the user gets the same toast and the
-      // same JSON-format URL we offer from the toolbar.
+      // Append a space + inline link + period to the friendly sentence.
+      // Clicking it copies the query link: the query timed out here, so what
+      // the user needs is a way to run it from a tool without this page's
+      // patience. Not the Connect panel, which hangs off a button in the
+      // results toolbar — and the toolbar is hidden whenever there is an error.
       this.resultsErrorMessage.appendChild(document.createTextNode(' You can still '));
       const link = document.createElement('a');
       link.href = '#';
       link.textContent = action.label;
       link.addEventListener('click', (e) => {
         e.preventDefault();
-        this.queryResults?.onShare('query-link');
+        this.queryResults?.copyQueryLink();
       });
       this.resultsErrorMessage.appendChild(link);
       this.resultsErrorMessage.appendChild(document.createTextNode(' to use the query from a tool that can handle long-running requests.'));
@@ -555,7 +556,7 @@ export class QueryEditor {
 
   /**
    * Minify the SPARQL query. The return value is fed directly into
-   * `encodeURIComponent` for Copy URL / Share view, so it must never
+   * `encodeURIComponent` for the connect link / Share view, so it must never
    * throw — a parse failure would bubble out of the click handler as
    * an unhandled rejection and leave the button in a broken state.
    * On parse failure, fall back to the raw query: the resulting URL

--- a/src/js/QueryResults.js
+++ b/src/js/QueryResults.js
@@ -41,7 +41,6 @@ export class QueryResults {
     this.queryEditor = queryEditor;
     this.originalSparqlEndpoint = originalSparqlEndpoint;
     this.resultsDiv = document.getElementById("results");
-    this.copyUrlButton = document.getElementById('copy-url-button');
     this.copyUrlAlert = document.getElementById('copy-url-alert');
     this.queryResultsTab = new bootstrap.Tab(document.getElementById('query-results-tab'));
     this.chartView = new ChartView();
@@ -51,13 +50,20 @@ export class QueryResults {
 
   /**
    * Initialize event listeners.
-   * Wires the Copy URL button and every dropdown item in the
+   * Wires the Copy Query dropdown items and every dropdown item in the
    * "Download as…" menu. Each download item carries a
    * data-download-format attribute with the MIME type to request.
    */
   initEventListeners() {
-    this.copyUrlButton.addEventListener('click', this.onCopyUrl.bind(this));
+    // Copy Query dropdown items
+    document.querySelectorAll('#copy-url-alert [data-share-type]').forEach(item => {
+      item.addEventListener('click', (e) => {
+        e.preventDefault();
+        this.onShare(item.dataset.shareType);
+      });
+    });
 
+    // Download as… dropdown items
     document.querySelectorAll('#copy-url-alert [data-download-format]').forEach(item => {
       item.addEventListener('click', (e) => {
         e.preventDefault();
@@ -85,7 +91,7 @@ export class QueryResults {
 
   /**
    * Show or hide the slim results toolbar (the strip above the table
-   * that holds the hint, the Copy endpoint URL button and the
+   * that holds the hint, the Copy Query dropdown and the
    * Download as… menu). Centralised here so every lane that needs to
    * toggle it (displayJsonResults, displayTextResults, the SELECT
    * submit paths in QueryEditor) goes through one place.
@@ -206,6 +212,24 @@ export class QueryResults {
   }
 
   /**
+   * Build a ready-to-paste cURL command that reproduces a SPARQL POST
+   * request. The body is a URL-encoded `application/x-www-form-urlencoded`
+   * string (from `buildSparqlBody`); it is wrapped in single quotes for
+   * the shell, so any literal single quote inside it (e.g. from a SPARQL
+   * string literal like `FILTER(?name = 'John')`) is percent-encoded to
+   * %27 first — otherwise it would prematurely close the shell's quoted
+   * argument and corrupt or break the command.
+   *
+   * @param {string} endpoint - The SPARQL endpoint URL.
+   * @param {string} body - The url-encoded POST body (from buildSparqlBody).
+   * @returns {string} - The full curl command, ready to paste into a terminal.
+   */
+  static _buildCurlCommand(endpoint, body) {
+    const safeBody = body.replace(/'/g, '%27');
+    return `curl -X POST '${endpoint}' \\\n  -H 'Content-Type: application/x-www-form-urlencoded' \\\n  -H 'Accept: application/sparql-results+json' \\\n  -d '${safeBody}'`;
+  }
+
+  /**
    * Display text results.
    * @param {string} content - The text content.
    * @param {string} type - The content type (e.g., 'xml', 'csv', 'text').
@@ -234,28 +258,54 @@ export class QueryResults {
   }
 
   /**
-   * Handle copy URL button click event.
-   * Generates a URL for the current query and copies it to the
-   * clipboard. Uses the shared `copyToClipboard` helper so insecure
-   * contexts (non-HTTPS, older browsers) get the execCommand
-   * fallback instead of a synchronous throw, and a real failure
-   * surfaces via the shared toast instead of a silent
-   * console.error.
+   * Handle share dropdown item click.
+   * Copies the appropriate content to the clipboard based on the
+   * selected share type.
+   * @param {string} type - The share type: 'query-link', 'sparql-query', or 'curl-command'.
    */
-  async onCopyUrl() {
-    const url = this.generateUrl();
-    const copied = await copyToClipboard(url);
+  async onShare(type) {
+    const query = this.queryEditor.getQuery();
+    if (!query || !query.trim()) {
+      showToast('Nothing to copy', 'Write a query first, then try again.', { variant: 'warning' });
+      return;
+    }
+
+    let textToCopy;
+    let toastTitle;
+    let toastBody;
+
+    switch (type) {
+      case 'query-link': {
+        textToCopy = this.generateUrl();
+        toastTitle = 'Query link copied';
+        toastBody = 'Open this link in a browser or any HTTP client to re-run the query and get JSON results.';
+        break;
+      }
+      case 'sparql-query': {
+        textToCopy = query;
+        toastTitle = 'SPARQL query copied';
+        toastBody = 'Paste this into any SPARQL editor to run the same query.';
+        break;
+      }
+      case 'curl-command': {
+        const minifiedQuery = this.queryEditor.minifySparqlQuery(query);
+        const body = buildSparqlBody(minifiedQuery);
+        textToCopy = QueryResults._buildCurlCommand(this.originalSparqlEndpoint, body);
+        toastTitle = 'cURL command copied';
+        toastBody = 'Paste into a terminal to execute the query via command line.';
+        break;
+      }
+      default:
+        return;
+    }
+
+    const copied = await copyToClipboard(textToCopy);
     if (copied) {
-      // SELECT-lane specific success copy: the URL is a JSON
-      // endpoint, consumable by Excel / Power BI / any HTTP client.
-      showToast(
-        'Query URL copied',
-        'You can use it in any app that can load JSON data from the web like Excel, Power BI, etc.',
-      );
+      showToast(toastTitle, toastBody);
     } else {
       showToast(
         'Copy failed',
-        'Could not copy the URL to the clipboard. Please copy it manually from the address bar after clicking Run Query.',
+        'Could not copy to the clipboard. Please try again.',
         { variant: 'danger' },
       );
     }

--- a/src/js/QueryResults.js
+++ b/src/js/QueryResults.js
@@ -50,18 +50,28 @@ export class QueryResults {
 
   /**
    * Initialize event listeners.
-   * Wires the Copy Query dropdown items and every dropdown item in the
+   * Wires the Connect dialog and every dropdown item in the
    * "Download as…" menu. Each download item carries a
    * data-download-format attribute with the MIME type to request.
    */
   initEventListeners() {
-    // Copy Query dropdown items
-    document.querySelectorAll('#copy-url-alert [data-share-type]').forEach(item => {
-      item.addEventListener('click', (e) => {
-        e.preventDefault();
-        this.onShare(item.dataset.shareType);
+    // The Connect panel hangs off its button as a popover rather than taking
+    // the screen: what it describes is the query whose results are on show
+    // behind it. The markup lives in the page and is handed to Bootstrap as
+    // the popover's content, so these listeners are wired once and survive
+    // the panel being shown and hidden.
+    // Held rather than looked up later: once the popover has been shown and
+    // hidden, Bootstrap has detached its tip and the panel with it, so the
+    // panel is no longer findable in the document.
+    const panel = document.getElementById('connect-panel');
+    this._connectPanel = panel;
+    if (panel) {
+      panel.querySelectorAll('[data-connect-copy]').forEach(button => {
+        button.addEventListener('click', () => this.onConnectCopy(button.dataset.connectCopy));
       });
-    });
+      document.getElementById('connect-button')
+        ?.addEventListener('click', () => this.toggleConnectPanel());
+    }
 
     // Download as… dropdown items
     document.querySelectorAll('#copy-url-alert [data-download-format]').forEach(item => {
@@ -73,25 +83,8 @@ export class QueryResults {
   }
 
   /**
-   * Generate a shareable URL for the current query.
-   * Always emits a SPARQL Results JSON URL — that's the most
-   * machine-friendly format for Excel, Power BI and custom apps,
-   * and matches what the editor renders on screen.
-   * @returns {string} - The generated URL.
-   */
-  generateUrl() {
-    const query = this.queryEditor.getQuery();
-    const minifiedQuery = this.queryEditor.minifySparqlQuery(query);
-    // Always emits a JSON URL — that's the most machine-friendly
-    // format for Excel, Power BI and custom apps. The `originalSparqlEndpoint`
-    // field is the public endpoint (not the dev-mode /proxy wrapper),
-    // so the copied URL is usable outside the app.
-    return buildSparqlUrl(this.originalSparqlEndpoint, minifiedQuery);
-  }
-
-  /**
    * Show or hide the slim results toolbar (the strip above the table
-   * that holds the hint, the Copy Query dropdown and the
+   * that holds the hint, the Connect your app button and the
    * Download as… menu). Centralised here so every lane that needs to
    * toggle it (displayJsonResults, displayTextResults, the SELECT
    * submit paths in QueryEditor) goes through one place.
@@ -220,13 +213,21 @@ export class QueryResults {
    * %27 first — otherwise it would prematurely close the shell's quoted
    * argument and corrupt or break the command.
    *
+   * The Accept header states the format the body asks for. Sending one that
+   * contradicts it is not merely untidy: the endpoint answers 406 Not
+   * Acceptable and the command returns nothing at all.
+   *
    * @param {string} endpoint - The SPARQL endpoint URL.
    * @param {string} body - The url-encoded POST body (from buildSparqlBody).
+   * @param {string} format - The MIME type that body asks for.
    * @returns {string} - The full curl command, ready to paste into a terminal.
    */
-  static _buildCurlCommand(endpoint, body) {
+  static _buildCurlCommand(endpoint, body, format) {
     const safeBody = body.replace(/'/g, '%27');
-    return `curl -X POST '${endpoint}' \\\n  -H 'Content-Type: application/x-www-form-urlencoded' \\\n  -H 'Accept: application/sparql-results+json' \\\n  -d '${safeBody}'`;
+    return `curl -X POST '${endpoint}' \\\n`
+      + `  -H 'Content-Type: application/x-www-form-urlencoded' \\\n`
+      + `  -H 'Accept: ${format}' \\\n`
+      + `  -d '${safeBody}'`;
   }
 
   /**
@@ -258,56 +259,309 @@ export class QueryResults {
   }
 
   /**
-   * Handle share dropdown item click.
-   * Copies the appropriate content to the clipboard based on the
-   * selected share type.
-   * @param {string} type - The share type: 'query-link', 'sparql-query', or 'curl-command'.
+   * The formats a SELECT query can be asked for from another application.
+   *
+   * The Download menu's list less "Spreadsheet", which is not a format: the
+   * endpoint returns the same HTML page it returns for text/html, labelled
+   * application/vnd.ms-excel so that a browser hands the file to Excel
+   * instead of rendering it. That is a download convention, and it reads
+   * sensibly on a Download menu. A link built from it returns markup, which
+   * is not what anyone connecting an application is asking for.
    */
-  async onShare(type) {
+  static CONNECT_FORMATS = [
+    { mime: 'application/sparql-results+json', label: 'JSON' },
+    { mime: 'text/csv', label: 'CSV' },
+    { mime: 'text/tab-separated-values', label: 'TSV' },
+    { mime: 'application/sparql-results+xml', label: 'XML' },
+  ];
+
+  /**
+   * Build a ready-to-paste PowerShell command.
+   *
+   * Not a cURL command in disguise: inside PowerShell, `curl` is an alias for
+   * Invoke-WebRequest and takes different arguments, so a pasted cURL line
+   * fails there with an error that says nothing useful. Invoke-RestMethod is
+   * what a Windows user actually has, and it parses the response rather than
+   * handing back text.
+   *
+   * A PowerShell single-quoted string escapes a quote by doubling it.
+   *
+   * @param {string} endpoint - The SPARQL endpoint URL.
+   * @param {string} body - The url-encoded POST body (from buildSparqlBody).
+   * @returns {string}
+   */
+  /**
+   * Build a ready-to-paste wget command.
+   *
+   * Not redundant beside cURL: a minimal Debian ships wget and not curl, which
+   * is the sort of machine a scheduled job runs on. `-O -` writes to the
+   * screen rather than to a file, which is what wget would otherwise do.
+   *
+   * Single quotes in the body are percent-encoded for the same reason as in
+   * the cURL command: they would close the shell's quoted argument.
+   *
+   * @param {string} endpoint - The SPARQL endpoint URL.
+   * @param {string} body - The url-encoded POST body (from buildSparqlBody).
+   * @returns {string}
+   */
+  static _buildWgetCommand(endpoint, body, format) {
+    const safeBody = body.replace(/'/g, '%27');
+    return `wget -qO - '${endpoint}' \\\n`
+      + `  --header='Content-Type: application/x-www-form-urlencoded' \\\n`
+      + `  --header='Accept: ${format}' \\\n`
+      + `  --post-data='${safeBody}'`;
+  }
+
+  static _buildPowerShellCommand(endpoint, body, format) {
+    const quoted = (value) => `'${String(value).replace(/'/g, "''")}'`;
+    return `Invoke-RestMethod -Method Post -Uri ${quoted(endpoint)} \`
+`
+      + `  -ContentType 'application/x-www-form-urlencoded' \`
+`
+      + `  -Headers @{ Accept = ${quoted(format)} } \`
+`
+      + `  -Body ${quoted(body)}`;
+  }
+
+  /**
+   * What one button of the Connect dialog puts on the clipboard.
+   *
+   * Built when the button is pressed rather than held: each button carries its
+   * own format, and the query can change while the dialog is open.
+   *
+   * @param {string} key - link | curl | powershell | sparql
+   * @param {string} format - A MIME type. Ignored for `sparql`, which is the
+   *   query text and the same whatever the endpoint is asked to return.
+   * @returns {string}
+   */
+  buildConnectSnippet(key, format) {
+    const query = this.queryEditor.getQuery();
+    if (key === 'sparql') return query;
+
+    const minifiedQuery = this.queryEditor.minifySparqlQuery(query);
+    if (key === 'link') {
+      return buildSparqlUrl(this.originalSparqlEndpoint, minifiedQuery, format);
+    }
+
+    const body = buildSparqlBody(minifiedQuery, format);
+    const build = {
+      curl: QueryResults._buildCurlCommand,
+      wget: QueryResults._buildWgetCommand,
+      powershell: QueryResults._buildPowerShellCommand,
+    }[key];
+    return build ? build(this.originalSparqlEndpoint, body, format) : '';
+  }
+
+  /**
+   * Fill the Connect dialog's format menus, and show what each button will
+   * return.
+   *
+   * Every button that has a format carries its own, so a button states what
+   * it produces rather than inheriting a choice made elsewhere in the dialog.
+   * The menus are written once and then left alone, so a choice survives the
+   * dialog being closed and opened again.
+   */
+  fillConnectDialog() {
+    // Within the panel, not the document: while the popover is hidden the
+    // panel is detached, and its contents are not reachable from either.
+    const panel = this._connectPanel;
+    if (!panel) return;
+
+    // The link's split button: the format is a choice it carries, so that
+    // copying stays one click for whoever already has the format they want.
+    for (const menu of panel.querySelectorAll('[data-connect-format-menu]')) {
+      const key = menu.dataset.connectFormatMenu;
+
+      if (!menu.children.length) {
+        // The same stem as the commands: "link to get JSON". The format is
+        // what the link fetches, not what the link is.
+        const header = document.createElement('li');
+        header.innerHTML = '<h6 class="dropdown-header">Link to get</h6>';
+        menu.appendChild(header);
+
+        for (const { mime, label } of QueryResults.CONNECT_FORMATS) {
+          menu.appendChild(this._connectMenuItem(label, () => {
+            // Choosing a format copies, as it does on the command menus. It is
+            // also remembered, so the button's own half becomes a one-click
+            // repeat of whatever was used last.
+            this._connectFormats[key] = mime;
+            this.fillConnectDialog();
+            this.onConnectCopy(key, mime);
+          }));
+        }
+      }
+
+      const format = this.connectFormatFor(key);
+      const chosen = QueryResults.CONNECT_FORMATS.find(f => f.mime === format);
+      const name = panel.querySelector(`[data-connect-format-name="${key}"]`);
+      if (name) name.textContent = chosen ? chosen.label : format;
+    }
+
+    // The commands: each item copies in that format, so nothing is carried
+    // and nothing is assumed.
+    for (const menu of panel.querySelectorAll('[data-connect-copy-menu]')) {
+      if (menu.children.length) continue;
+      const key = menu.dataset.connectCopyMenu;
+
+      // A stem the items complete: "command to get JSON". Not "copy as JSON",
+      // which says the clipboard gets JSON; it gets a command, and JSON is
+      // what running the command fetches.
+      const header = document.createElement('li');
+      header.innerHTML = '<h6 class="dropdown-header">Command to get</h6>';
+      menu.appendChild(header);
+
+      for (const { mime, label } of QueryResults.CONNECT_FORMATS) {
+        menu.appendChild(this._connectMenuItem(label, () => this.onConnectCopy(key, mime)));
+      }
+    }
+  }
+
+  /** One item of a Connect menu. */
+  _connectMenuItem(label, onClick) {
+    const item = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'dropdown-item';
+    button.textContent = label;
+    button.addEventListener('click', onClick);
+    item.appendChild(button);
+    return item;
+  }
+
+  /** The format a given Connect button will return; the first one until chosen. */
+  connectFormatFor(key) {
+    this._connectFormats ??= {};
+    return this._connectFormats[key] ?? QueryResults.CONNECT_FORMATS[0].mime;
+  }
+
+  /**
+   * Show or hide the Connect panel.
+   *
+   * The popover is built on first use and kept, so the panel element is moved
+   * in and out of it rather than rebuilt — which is what lets the listeners
+   * wired at start-up go on working.
+   */
+  toggleConnectPanel() {
+    const button = document.getElementById('connect-button');
+    const panel = this._connectPanel;
+    if (!button || !panel || typeof bootstrap === 'undefined' || !bootstrap.Popover) return;
+
+    if (!this._connectPopover) {
+      this._connectPopover = new bootstrap.Popover(button, {
+        content: panel,
+        html: true,
+        sanitize: false,
+        placement: 'bottom',
+        trigger: 'manual',
+        container: 'body',
+        customClass: 'connect-popover',
+        offset: [0, 14],
+      });
+
+      // Dismiss on a click outside it. Clicks within stay: the format menus
+      // live inside the panel, and choosing one must not close it.
+      document.addEventListener('click', (e) => {
+        if (!this._connectPopoverShown) return;
+        const tip = this._connectPopover.tip;
+        if (tip?.contains(e.target) || button.contains(e.target)) return;
+        this.hideConnectPanel();
+      }, true);
+
+      document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') this.hideConnectPanel();
+      });
+    }
+
+    if (this._connectPopoverShown) {
+      this.hideConnectPanel();
+      return;
+    }
+
+    this.fillConnectDialog();
+    this._connectPopover.show();
+    this._connectPopoverShown = true;
+    // While the panel is open the call to action is inside it. The button that
+    // opened it steps back rather than competing with its own Copy link.
+    button.classList.add('connect-open');
+    button.setAttribute('aria-expanded', 'true');
+
+    // The popover is appended to the body, far from the button in tab order,
+    // so tabbing from the button walks past the panel into the rest of the
+    // page. Focus is moved in, and put back on the button when it closes.
+    const tip = this._connectPopover.tip;
+    if (tip) {
+      tip.setAttribute('role', 'dialog');
+      tip.setAttribute('aria-label', 'Connect your app');
+      tip.querySelector('button, [href], select, input')?.focus();
+    }
+  }
+
+  hideConnectPanel() {
+    if (!this._connectPopoverShown) return;
+    const button = document.getElementById('connect-button');
+    // Before the popover goes: focus inside it is about to be destroyed, and
+    // the browser would drop it on the body.
+    if (button && this._connectPopover.tip?.contains(document.activeElement)) {
+      button.focus();
+    }
+    this._connectPopover.hide();
+    this._connectPopoverShown = false;
+    button?.classList.remove('connect-open');
+    button?.setAttribute('aria-expanded', 'false');
+  }
+
+  /**
+   * Copy the query link without going through the panel.
+   *
+   * For the timeout recovery message, which offers this when a query took too
+   * long for the browser. The results toolbar is hidden on any error, and the
+   * panel hangs off a button inside it — so there is nothing to hang it from
+   * at the one moment it is most wanted. The link is the whole of what that
+   * message is offering anyway.
+   */
+  copyQueryLink() {
+    return this.onConnectCopy('link');
+  }
+
+  /**
+   * Copy one snippet from the Connect dialog.
+   *
+   * @param {string} key - link | curl | powershell | sparql
+   * @param {string} [format] - A MIME type. The commands name one at the
+   *   moment of copying; the link carries the one shown on its button.
+   */
+  async onConnectCopy(key, format = undefined) {
     const query = this.queryEditor.getQuery();
     if (!query || !query.trim()) {
       showToast('Nothing to copy', 'Write a query first, then try again.', { variant: 'warning' });
       return;
     }
 
-    let textToCopy;
-    let toastTitle;
-    let toastBody;
+    const chosenFormat = format ?? this.connectFormatFor(key);
+    const value = this.buildConnectSnippet(key, chosenFormat);
+    if (!value) return;
 
-    switch (type) {
-      case 'query-link': {
-        textToCopy = this.generateUrl();
-        toastTitle = 'Query link copied';
-        toastBody = 'Open this link in a browser or any HTTP client to re-run the query and get JSON results.';
-        break;
-      }
-      case 'sparql-query': {
-        textToCopy = query;
-        toastTitle = 'SPARQL query copied';
-        toastBody = 'Paste this into any SPARQL editor to run the same query.';
-        break;
-      }
-      case 'curl-command': {
-        const minifiedQuery = this.queryEditor.minifySparqlQuery(query);
-        const body = buildSparqlBody(minifiedQuery);
-        textToCopy = QueryResults._buildCurlCommand(this.originalSparqlEndpoint, body);
-        toastTitle = 'cURL command copied';
-        toastBody = 'Paste into a terminal to execute the query via command line.';
-        break;
-      }
-      default:
-        return;
-    }
+    // The format is named back, because it was chosen a moment ago in a menu
+    // that has already closed. The query carries none: it is the same text
+    // whatever the endpoint is asked to return.
+    const label = QueryResults.CONNECT_FORMATS.find(f => f.mime === chosenFormat)?.label;
+    const returns = key === 'sparql' || !label ? '' : ` It returns ${label}.`;
 
-    const copied = await copyToClipboard(textToCopy);
-    if (copied) {
-      showToast(toastTitle, toastBody);
+    const said = {
+      link: ['Link copied', 'Paste it into Excel, Power BI, or anything that reads data from the web.'],
+      curl: ['cURL command copied', 'Paste it into a terminal on macOS or Linux.'],
+      wget: ['wget command copied', 'Paste it into a terminal on Linux.'],
+      powershell: ['PowerShell command copied', 'Paste it into PowerShell on Windows.'],
+      sparql: ['SPARQL query copied', 'Paste it into an app that speaks SPARQL to run the same query.'],
+    }[key];
+
+    if (await copyToClipboard(value)) {
+      // The panel has done its job; leaving it open covers the results it
+      // describes and asks the user to dismiss something they are finished with.
+      this.hideConnectPanel();
+      showToast(said[0], said[1] + returns);
     } else {
-      showToast(
-        'Copy failed',
-        'Could not copy to the clipboard. Please try again.',
-        { variant: 'danger' },
-      );
+      showToast('Copy failed', 'Could not copy to the clipboard. Please try again.', { variant: 'danger' });
     }
   }
 

--- a/src/js/sparqlRequest.js
+++ b/src/js/sparqlRequest.js
@@ -15,8 +15,8 @@
 //
 // Three sites build the same parameter block for the Virtuoso endpoint:
 // QueryEditor.onSubmit (POST body), QueryResults.downloadAs (POST body
-// with a caller-supplied format), and QueryResults.generateUrl (GET URL
-// for Copy Query). Consolidating them here keeps them honest so the
+// with a caller-supplied format), and the Connect panel (a GET URL
+// for Connect your app). Consolidating them here keeps them honest so the
 // query link reproduces exactly what "Run Query" just ran.
 //
 // The options they carry used to come from the Customize tab's Options
@@ -65,9 +65,9 @@ export function buildSparqlBody(query, format = DEFAULT_FORMAT) {
 
 /**
  * Build a GET URL that, when fetched, returns the same result as
- * running the query from the editor. Used by the "Copy Query" →
- * "Query link" option so the user can paste the URL into Excel /
- * Power BI / any HTTP client.
+ * running the query from the editor. Used by the "Connect your app"
+ * dialog so the user can paste the URL into Excel / Power BI / any
+ * HTTP client.
  *
  * Applies the same `default-graph-uri` / `timeout` omission rules as
  * `buildSparqlBody` — the copied URL is an exact reproduction of

--- a/src/js/sparqlRequest.js
+++ b/src/js/sparqlRequest.js
@@ -16,8 +16,8 @@
 // Three sites build the same parameter block for the Virtuoso endpoint:
 // QueryEditor.onSubmit (POST body), QueryResults.downloadAs (POST body
 // with a caller-supplied format), and QueryResults.generateUrl (GET URL
-// for Copy endpoint URL). Consolidating them here keeps them honest so
-// "Copy endpoint URL" reproduces exactly what "Run Query" just ran.
+// for Copy Query). Consolidating them here keeps them honest so the
+// query link reproduces exactly what "Run Query" just ran.
 //
 // The options they carry used to come from the Customize tab's Options
 // panel; that UI was removed (issue #32), so readSparqlOptions now returns
@@ -65,9 +65,9 @@ export function buildSparqlBody(query, format = DEFAULT_FORMAT) {
 
 /**
  * Build a GET URL that, when fetched, returns the same result as
- * running the query from the editor. Used by the "Copy endpoint
- * URL" button so the user can paste the URL into Excel / Power BI /
- * any HTTP client.
+ * running the query from the editor. Used by the "Copy Query" →
+ * "Query link" option so the user can paste the URL into Excel /
+ * Power BI / any HTTP client.
  *
  * Applies the same `default-graph-uri` / `timeout` omission rules as
  * `buildSparqlBody` — the copied URL is an exact reproduction of

--- a/src/js/tours/reuseSelectTour.js
+++ b/src/js/tours/reuseSelectTour.js
@@ -47,11 +47,10 @@ export function startReuseSelectTour() {
   steps.push(
     {
       element: '#copy-url-button',
-      title: 'Copy endpoint URL',
+      title: 'Copy Query',
       content:
-        'Copies a URL that returns exactly these results as JSON. Paste it into Excel, ' +
-        'Power BI or any other application that can load JSON from a URL, and you will always ' +
-        'see the latest data without having to re-run the query by hand.',
+        'Copy the query as a link, raw SPARQL text, or a cURL command. The query link returns ' +
+        'these results as JSON — paste it into Excel, Power BI or any HTTP client for live data.',
       placement: 'bottom',
     },
     {

--- a/src/js/tours/reuseSelectTour.js
+++ b/src/js/tours/reuseSelectTour.js
@@ -46,11 +46,12 @@ export function startReuseSelectTour() {
 
   steps.push(
     {
-      element: '#copy-url-button',
-      title: 'Copy Query',
+      element: '#connect-button',
+      title: 'Connect your app',
       content:
-        'Copy the query as a link, raw SPARQL text, or a cURL command. The query link returns ' +
-        'these results as JSON — paste it into Excel, Power BI or any HTTP client for live data.',
+        'Run this query from your own tools. You get a link to paste into Excel or Power BI, ' +
+        'which re-runs the query every time you refresh, and the same request as a command ' +
+        'for a terminal.',
       placement: 'bottom',
     },
     {

--- a/test/queryResults.test.js
+++ b/test/queryResults.test.js
@@ -138,11 +138,28 @@ test('_renderCell does not make a javascript: URI clickable', () => {
 // command — these tests pin the %27 escaping that prevents that.
 
 test('_buildCurlCommand includes the endpoint, method, and headers', () => {
-  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', 'query=x');
+  const cmd = QueryResults._buildCurlCommand(
+    'https://example.com/sparql', 'query=x', 'application/sparql-results+json');
   assert.match(cmd, /^curl -X POST 'https:\/\/example\.com\/sparql'/);
   assert.match(cmd, /-H 'Content-Type: application\/x-www-form-urlencoded'/);
   assert.match(cmd, /-H 'Accept: application\/sparql-results\+json'/);
   assert.match(cmd, /-d 'query=x'/);
+});
+
+test('every command asks for the format its body asks for', () => {
+  // A body requesting CSV under an Accept header naming JSON is not merely
+  // untidy: the endpoint answers 406 Not Acceptable and nothing comes back.
+  const panel = panelFor("SELECT ('John' AS ?name) WHERE { }");
+
+  for (const { mime } of QueryResults.CONNECT_FORMATS) {
+    for (const key of ['curl', 'wget', 'powershell']) {
+      const command = panel.buildConnectSnippet(key, mime);
+      assert.ok(command.includes(`Accept: ${mime}`) || command.includes(`Accept = '${mime}'`),
+        `${key} asks for ${mime}:\n${command}`);
+      assert.ok(command.includes(`format=${encodeURIComponent(mime)}`),
+        `${key} sends ${mime}`);
+    }
+  }
 });
 
 test('_buildCurlCommand escapes a literal single quote in the body to %27', () => {
@@ -168,4 +185,126 @@ test('_buildCurlCommand produces a single-quoted -d argument with no unescaped q
   const match = cmd.match(/-d '([^\n]*)'$/);
   assert.ok(match, 'the -d argument should be present and single-quoted');
   assert.doesNotMatch(match[1], /'/, 'the body inside the quotes must not contain a raw single quote');
+});
+
+// ── the Connect panel ───────────────────────────────────────────────
+//
+// The panel offers the same request in several shapes. Two things have to
+// hold: each shape has to be a working request, and the shell ones have to
+// survive being pasted into a shell — a SPARQL string literal carries single
+// quotes, and a single-quoted shell argument ends at the first one it meets.
+
+const ENDPOINT = 'https://publications.europa.eu/webapi/rdf/sparql';
+
+// The panel's own builders, without a DOM: QueryResults reads the query from
+// the editor and the endpoint from its constructor, and nothing else.
+function panelFor(query) {
+  const results = Object.create(QueryResults.prototype);
+  results.originalSparqlEndpoint = ENDPOINT;
+  results.queryEditor = {
+    getQuery: () => query,
+    minifySparqlQuery: (q) => q.replace(/\s+/g, ' ').trim(),
+  };
+  return results;
+}
+
+const QUOTED_QUERY = "SELECT ('John' AS ?name) WHERE { }";
+
+test('every command carries the endpoint and the query', () => {
+  const panel = panelFor(QUOTED_QUERY);
+
+  for (const key of ['curl', 'wget', 'powershell']) {
+    const command = panel.buildConnectSnippet(key, 'text/csv');
+    assert.ok(command.includes(ENDPOINT), `${key} names the endpoint`);
+    assert.ok(command.includes('query=SELECT'), `${key} carries the query`);
+    assert.ok(command.includes(encodeURIComponent('text/csv')), `${key} carries the format`);
+  }
+});
+
+test('no shell command leaves a single quote loose in a quoted argument', () => {
+  // The failure this prevents: the shell ends the argument at the stray
+  // quote, and the endpoint receives `SELECT (John AS ?name)` — verified
+  // against the live endpoint, which answers with a syntax error.
+  for (const key of ['curl', 'wget']) {
+    const command = panelFor(QUOTED_QUERY).buildConnectSnippet(key, 'application/sparql-results+json');
+    const quotedArguments = command.match(/'[^']*'/g) || [];
+    const rejoined = quotedArguments.join('');
+    assert.equal((command.match(/'/g) || []).length, (rejoined.match(/'/g) || []).length,
+      `${key}: every quote in the command opens or closes an argument`);
+    assert.ok(command.includes('%27'), `${key}: the query's own quotes are encoded`);
+  }
+});
+
+test('PowerShell doubles a quote rather than percent-encoding it', () => {
+  // Its strings are not the shell's: PowerShell escapes a single quote by
+  // doubling it, and would send a literal %27 to the endpoint as data.
+  const command = panelFor(QUOTED_QUERY).buildConnectSnippet('powershell', 'text/csv');
+
+  assert.ok(command.includes('Invoke-RestMethod'), 'not a cURL line in disguise');
+  assert.ok(!command.includes('%27'), 'no shell-style encoding');
+});
+
+test('a cURL command is not a PowerShell command', () => {
+  // Inside PowerShell, `curl` is an alias for Invoke-WebRequest and takes
+  // different arguments, so one cannot stand in for the other.
+  const panel = panelFor(QUOTED_QUERY);
+
+  assert.notEqual(
+    panel.buildConnectSnippet('curl', 'text/csv'),
+    panel.buildConnectSnippet('powershell', 'text/csv'),
+  );
+});
+
+test('wget writes to the screen, not to a file', () => {
+  // Its default is to save, which would leave someone wondering where the
+  // results went.
+  const command = panelFor(QUOTED_QUERY).buildConnectSnippet('wget', 'text/csv');
+  assert.match(command, /wget -qO -/);
+});
+
+test('the link is a GET URL carrying the chosen format', () => {
+  const link = panelFor(QUOTED_QUERY).buildConnectSnippet('link', 'text/tab-separated-values');
+
+  assert.ok(link.startsWith(`${ENDPOINT}?`));
+  assert.ok(link.includes(encodeURIComponent('text/tab-separated-values')));
+});
+
+test('the query is offered as written, minified for the rest', () => {
+  // What goes into another app is the query someone wrote, not a machine's
+  // one-line version of it.
+  const written = 'SELECT ?s\nWHERE {\n  ?s ?p ?o\n}';
+  const panel = panelFor(written);
+
+  assert.equal(panel.buildConnectSnippet('sparql', 'text/csv'), written);
+  assert.ok(panel.buildConnectSnippet('curl', 'text/csv').includes(encodeURIComponent('SELECT ?s WHERE')));
+});
+
+test('the format makes no difference to the query itself', () => {
+  const panel = panelFor(QUOTED_QUERY);
+  assert.equal(
+    panel.buildConnectSnippet('sparql', 'text/csv'),
+    panel.buildConnectSnippet('sparql', 'application/sparql-results+xml'),
+  );
+});
+
+test('the formats offered are the ones an application can consume', () => {
+  // Not the Download menu's list: "Spreadsheet" is application/vnd.ms-excel,
+  // which the endpoint answers with the same HTML page it returns for
+  // text/html. A link built from it hands an application markup to scrape.
+  const labels = QueryResults.CONNECT_FORMATS.map(f => f.label);
+
+  assert.deepEqual(labels, ['JSON', 'CSV', 'TSV', 'XML']);
+});
+
+test('the timeout recovery copies the link rather than opening the panel', () => {
+  // The panel hangs off a button in the results toolbar, and the toolbar is
+  // hidden whenever there is an error — so at the one moment this is most
+  // wanted, there would be nothing to hang it from.
+  const panel = panelFor(QUOTED_QUERY);
+  const copied = [];
+  panel.onConnectCopy = (key) => { copied.push(key); };
+
+  panel.copyQueryLink();
+
+  assert.deepEqual(copied, ['link']);
 });

--- a/test/queryResults.test.js
+++ b/test/queryResults.test.js
@@ -127,3 +127,45 @@ test('_renderCell does not make a javascript: URI clickable', () => {
   // protocol so they never match — rendered as plain text.
   assert.equal(node.nodeType, 3);
 });
+
+// ── _buildCurlCommand ──────────────────────────────────────────────
+//
+// The generated command is pasted directly into a shell. A SPARQL query
+// containing a literal single quote (e.g. FILTER(?name = 'John')) survives
+// encodeURIComponent unescaped, since encodeURIComponent does not encode
+// `'`. Left as-is inside the curl command's single-quoted -d argument, it
+// would prematurely close the shell string and corrupt or break the
+// command — these tests pin the %27 escaping that prevents that.
+
+test('_buildCurlCommand includes the endpoint, method, and headers', () => {
+  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', 'query=x');
+  assert.match(cmd, /^curl -X POST 'https:\/\/example\.com\/sparql'/);
+  assert.match(cmd, /-H 'Content-Type: application\/x-www-form-urlencoded'/);
+  assert.match(cmd, /-H 'Accept: application\/sparql-results\+json'/);
+  assert.match(cmd, /-d 'query=x'/);
+});
+
+test('_buildCurlCommand escapes a literal single quote in the body to %27', () => {
+  // encodeURIComponent leaves ' unescaped, so a SPARQL string literal like
+  // FILTER(?name = 'John') would flow through as a bare quote here.
+  const bodyWithQuote = "query=FILTER(?name%20=%20'John')";
+  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', bodyWithQuote);
+  assert.doesNotMatch(cmd, /'John'/, 'a literal quote must not survive into the shell argument');
+  assert.match(cmd, /%27John%27/);
+});
+
+test('_buildCurlCommand leaves a body with no single quotes unchanged', () => {
+  const body = 'query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D&format=application%2Fsparql-results%2Bjson';
+  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', body);
+  assert.match(cmd, new RegExp(`-d '${body}'`));
+});
+
+test('_buildCurlCommand produces a single-quoted -d argument with no unescaped quote inside it', () => {
+  const bodyWithQuote = "query=a'b'c";
+  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', bodyWithQuote);
+  // Extract the -d argument's quoted content and confirm it contains no
+  // raw single quote (i.e. the shell would see exactly one quoted string).
+  const match = cmd.match(/-d '([^\n]*)'$/);
+  assert.ok(match, 'the -d argument should be present and single-quoted');
+  assert.doesNotMatch(match[1], /'/, 'the body inside the quotes must not contain a raw single quote');
+});

--- a/test/sparqlRequest.test.js
+++ b/test/sparqlRequest.test.js
@@ -87,7 +87,7 @@ test('buildSparqlUrl prefixes the endpoint with a ? separator', () => {
 });
 
 test('buildSparqlUrl produces the same parameter block as buildSparqlBody', () => {
-  // "Copy endpoint URL" must exactly reproduce what Run Query just ran.
+  // "Copy Query" link must exactly reproduce what Run Query just ran.
   const body = buildSparqlBody(QUERY);
   const url = buildSparqlUrl('https://example.com/sparql', QUERY);
   assert.equal(url, `https://example.com/sparql?${body}`);


### PR DESCRIPTION
Re-implementation of #113 on the reworked base, for issue #103 (@kvistgaard).

This branch sits on `rework/111-badge-types` (PR #119), so the diff shows only the sharing work. It contains @Anoop-Variyan's original #113 commit unchanged, with the rework on top, so the two can be compared directly.

## Why it changed

#113 replaced **Copy endpoint URL** with a **Copy Query** dropdown of three items. Two things in that need reopening.

**The button is the point of the site.** Someone who copies that link and wires it into their own application is a user who now depends on this data — which is what the service exists to produce, and what justifies continuing to publish it. It is the last step of the funnel, and everything else on the page exists to deliver somebody to it. In #113 it went from one click to two, to make room for two secondary items, and it was styled `btn-outline-secondary` beside a green **Download as…** — so the shallow path, take a file and leave, was the louder of the two.

**One of the three items already existed.** *SPARQL query* copies the editor's text, and the editor's own toolbar has a **Copy** button a few centimetres above it. #103 asked for a rename and pointed at YASGUI's share menu; YASGUI has that item because it has no separate copy button.

## What it is now

**Connect your app** — a solid green button, the loudest thing on the toolbar, opening a panel:

```
Paste this link into Excel, Power BI, or any tool that reads data
from the web. It re-runs your query and returns fresh data every time.

[ 📋 Copy link │ JSON ▾ ]
─────────────────────────────────────────────────────────────────
If you want to run this in a terminal, or in an app that speaks
SPARQL, use one of the buttons below.

[ 📋 cURL ▾ ]  [ 📋 wget ▾ ]  [ 📋 PowerShell ▾ ]  │  [ 📋 SPARQL ]
```

- **Copy link** is a split button: one click to copy, and the format it returns shown on its own half rather than hidden in a menu. Picking a format from that half copies too, and is remembered.
- **The commands** are menus whose every item copies — *Command to get → CSV*. The format is part of the act rather than a setting carried on the button, so nothing is inherited and nothing is assumed.
- **SPARQL** carries no format: the query text is the same whatever the endpoint is asked to return. The rule before it says so.
- Copying closes the panel and names the format back, because the menu that chose it has already closed.

The wording is the same in all four places a person meets it — the button, the Reuse tour step, the Help tab, and the home carousel, which already had a slide about this button.

## Also here

- **wget**, from #103's list. Not redundant beside cURL: a minimal Debian ships wget and not curl, which is the sort of machine a scheduled job runs on.
- **PowerShell** builds `Invoke-RestMethod`, not a cURL line. Inside PowerShell, `curl` is an alias for `Invoke-WebRequest` and takes different arguments, so a pasted cURL command fails there with an error that says nothing useful. Quotes are escaped by doubling, which is how PowerShell escapes them, where a shell needs `%27`.
- **Every format the SELECT lane offers**, not JSON alone. The dialog says "paste this into Excel", and Excel would rather have CSV. `buildSparqlUrl` already took a format; nothing passed one.
- **"Spreadsheet" is not offered here.** The endpoint answers `application/vnd.ms-excel` with the same HTML page it returns for `text/html`; only the header differs, so that a browser hands the file to Excel. It reads sensibly on a Download menu and hands an application markup to scrape. It stays on Download.
- **Download as…** is outlined green rather than grey: it is the same kind of act, one weight down. Neither button fills in while its menu is open, or the two become twins.
- **Bootstrap's blue pressed state** is gone, app-wide. The overrides set `background-color`, which reaches the resting and hover states but loses the pressed one, since 5.3 draws that from `--bs-btn-active-bg`.

## Retained from #113

The percent-encoding of single quotes in the shell body, which is the subtle part and is correct: `encodeURIComponent` leaves `'` alone, so a query containing `FILTER(?name = 'John')` would otherwise close the shell's quoted argument. Verified against the live endpoint — without it, Virtuoso receives `SELECT (John AS ?name)` and answers with a syntax error.

## Tests

526 pass, from 515. Every new behaviour was mutation-checked — the change reverted, the test seen to fail, the change restored.

Three defects were found by review after the tests were green, all in the panel's DOM behaviour, which the hand-written DOM stub cannot exercise (see #117):

- The cURL command sent `Accept: application/sparql-results+json` whatever format the body asked for. The endpoint answers **406 Not Acceptable**, so a CSV command returned nothing. Every command now states the format its body asks for; verified live for CSV and XML.
- The panel rendered at the page footer until first opened.
- Keyboard focus never entered the panel: the popover is appended to the body, so tabbing from the button walked past it into the rest of the page.

## Known limitations

- The panel's DOM behaviour is untested — the popover, the menus, the format state. See #117.
- PowerShell is verified by shape only; there is no Windows here to run it on. cURL, wget and the link were all run against the live endpoint.
