### PR TITLE
Query library reads from ted-open-data-examples (rework of #115)

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@
                                title="Take a quick tour of this tab">
                                 <i class="bi bi-play-circle"></i>
                             </a>
-                            <a href="https://docs.ted.europa.eu/ODS/latest/samples/contributing.html" target="_blank" rel="noopener noreferrer"
+                            <a href="https://github.com/OP-TED/ted-open-data-examples/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer"
                                id="contribute-query-link"
                                class="ms-auto small text-muted text-decoration-none"
                                data-bs-toggle="tooltip" data-bs-placement="top"
@@ -795,7 +795,7 @@
                         <p>
                             The Query Library provides example SPARQL queries to help you get started.
                             If you'd like to contribute new queries, improve existing ones, or add comments to make them clearer,
-                            see the <a href="https://docs.ted.europa.eu/ODS/latest/samples/contributing.html" target="_blank" rel="noopener noreferrer">contributing guide</a>.
+                            see the <a href="https://github.com/OP-TED/ted-open-data-examples/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">contributing guide</a>.
                         </p>
 
                         <h3>Questions &amp; feedback</h3>

--- a/src/js/QueryLibrary.js
+++ b/src/js/QueryLibrary.js
@@ -146,8 +146,8 @@ export class QueryLibrary {
       // All text is set via textContent and all identifiers are safely
       // slugified, so a query title or category name containing quotes,
       // angle brackets or HTML entities cannot escape the markup. The
-      // source YAML is trusted (OP-TED/ted-rdf-docs), but defence in depth
-      // is cheap here and prevents future supply-chain or typo issues.
+      // source YAML is trusted (OP-TED/ted-open-data-examples), but defence
+      // in depth is cheap here and prevents future supply-chain or typo issues.
       let categoryCounter = 0;
       categories.forEach((queries, category) => {
         const categoryId = `category-${categoryCounter++}`;

--- a/src/js/QueryLibrary.js
+++ b/src/js/QueryLibrary.js
@@ -126,7 +126,7 @@ export class QueryLibrary {
       // Fetch the YAML file containing the queries. Check
       // response.ok explicitly — otherwise a 404 HTML body flows
       // into yaml.load() and throws an opaque parse error.
-      const response = await fetch(`${this.remoteQueriesUrl}index.yaml`);
+      const response = await fetch(`${this.remoteQueriesUrl}web-library.yaml`);
       if (!response.ok) {
         throw new Error(`HTTP error. Status: ${response.status}`);
       }

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -30,7 +30,7 @@ import { SearchPanel } from './SearchPanel.js';
 import { setController } from './TermRenderer.js';
 
 const SPARQL_ENDPOINT = 'https://publications.europa.eu/webapi/rdf/sparql';
-const REMOTE_QUERIES_URL = 'https://raw.githubusercontent.com/OP-TED/ted-rdf-docs/main/docs/antora/modules/samples/queries/';
+const REMOTE_QUERIES_URL = 'https://raw.githubusercontent.com/OP-TED/ted-open-data-examples/main/';
 
 // Reset scroll on page load (browsers may restore previous scroll position).
 if ('scrollRestoration' in history) history.scrollRestoration = 'manual';


### PR DESCRIPTION
Re-implementation of #115 on the reworked base, for issue #75.

This branch sits on `rework/113-connect` (PR #121). It contains @Anoop-Variyan's two #115 commits unchanged, with one commit on top.

## What carried over unchanged

Both of Anoop's commits apply as written:

- `REMOTE_QUERIES_URL` → `https://raw.githubusercontent.com/OP-TED/ted-open-data-examples/main/`
- the manifest → `web-library.yaml`
- the trusted-source comment names the repository it now trusts

Verified against the live repository: the manifest answers 200 and lists 37 queries, the same number the old `index.yaml` listed, and a `.sparql` path from it resolves.

The third part of #115 — reading the parameter form's key from the basename of the sparql path — belongs to the query-library form mode, which is not in this base. It has nothing to attach to here and is left out.

## What is added

**The contribute links.** Three places in the application invite people to add a query, and all three pointed at `docs.ted.europa.eu/ODS/latest/samples/contributing.html`, which is a guide to contributing to `ted-rdf-docs`. After this switch the application would read its queries from one repository and send contributors to another.

They now point at [`ted-open-data-examples/CONTRIBUTING.md`](https://github.com/OP-TED/ted-open-data-examples/blob/main/CONTRIBUTING.md), which documents the `web-library.yaml` this application reads and the pull-request flow for it.

The Explore tour needed no change: its step targets the link's element rather than a URL.

## Tests

526 pass, unchanged. Nothing here is testable beyond what already is — the switch is two constants, and the links are markup.

## Left over

`docs.ted.europa.eu/ODS/latest/samples/contributing.html` still describes contributing to `ted-rdf-docs`, in four places. That page lives in another repository; it wants correcting or redirecting, along with removing the samples that moved.
