### PR TITLE
ci: run the tests, and keep main reachable only by release or hotfix

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,38 @@
+# `main` is what production serves, and it is reached one of two ways: a
+# release cut from `develop`, or a hotfix. Anything else — a feature branch, a
+# chore, `develop` itself — belongs in `develop` first, so that what ships is
+# what was tested together.
+#
+# GitHub has no setting for "only these branches may open a pull request into
+# this one", so this stands in for it: a check that fails when the source
+# branch is not one of the two, made required on `main`.
+#
+# No path filter, and no condition on the job: a required check that does not
+# run cannot be satisfied, and the pull request would wait for a status that
+# never arrives.
+name: guard main
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  source-branch:
+    name: source branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only a release or a hotfix may merge into main
+        env:
+          SOURCE: ${{ github.head_ref }}
+        run: |
+          case "$SOURCE" in
+            release/*|hotfix/*)
+              echo "Source branch '$SOURCE' may merge into main."
+              ;;
+            *)
+              echo "::error::'$SOURCE' cannot merge into main. Only release/* and hotfix/* branches may."
+              echo
+              echo "Merge this into develop instead, and let it reach main through a release."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+# Runs the test suite on every pull request and on the branches releases are
+# cut from, so a change cannot reach either with the suite failing.
+#
+# `npm ci` rather than `npm install`: it installs exactly what
+# package-lock.json records, so a run here tests the dependency versions the
+# lock file pins rather than whatever resolves today.
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+jobs:
+  test:
+    name: node --test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test


### PR DESCRIPTION
Two guards. The repository had neither.

## The tests

There was a test suite and nothing running it, so a pull request could merge with it failing. `update-exchange-rates.yml` was the only workflow.

Adds a `tests` workflow — `npm ci` then `npm test`, Node 20, matching the exchange-rates job — on every pull request and on pushes to `main` and `develop`. `npm ci` rather than `npm install`, so a run tests the versions `package-lock.json` pins rather than whatever resolves on the day.

## The source of a merge into main

`main` is what production serves, and it should be reached one of two ways: a release cut from `develop`, or a hotfix. Its history says otherwise — `FixEditorForStandardForm`, `ClickableLinks` and `chore/dependabot-transitive-bumps` all merged straight in.

GitHub has no setting for "only these branches may open a pull request into this one", so a check stands in for it: `guard main` fails when the source branch is neither `release/*` nor `hotfix/*`, with an error saying where the work belongs instead.

Nothing automated is affected — `update-exchange-rates.yml` pushes to `data/exchange-rates`, not to `main`.

## Neither workflow is path-filtered

Deliberately. A required check that only runs sometimes cannot be satisfied the rest of the time: nothing reports, and the pull request waits for a status that never arrives.

## After this merges

`node --test` and `source branch` become required checks on the branches they apply to. Until then they report and nothing depends on them.