### PR TITLE
ci: put the test and guard workflows on main

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,38 @@
+# `main` is what production serves, and it is reached one of two ways: a
+# release cut from `develop`, or a hotfix. Anything else — a feature branch, a
+# chore, `develop` itself — belongs in `develop` first, so that what ships is
+# what was tested together.
+#
+# GitHub has no setting for "only these branches may open a pull request into
+# this one", so this stands in for it: a check that fails when the source
+# branch is not one of the two, made required on `main`.
+#
+# No path filter, and no condition on the job: a required check that does not
+# run cannot be satisfied, and the pull request would wait for a status that
+# never arrives.
+name: guard main
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  source-branch:
+    name: source branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only a release or a hotfix may merge into main
+        env:
+          SOURCE: ${{ github.head_ref }}
+        run: |
+          case "$SOURCE" in
+            release/*|hotfix/*)
+              echo "Source branch '$SOURCE' may merge into main."
+              ;;
+            *)
+              echo "::error::'$SOURCE' cannot merge into main. Only release/* and hotfix/* branches may."
+              echo
+              echo "Merge this into develop instead, and let it reach main through a release."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+# Runs the test suite on every pull request and on the branches releases are
+# cut from, so a change cannot reach either with the suite failing.
+#
+# `npm ci` rather than `npm install`: it installs exactly what
+# package-lock.json records, so a run here tests the dependency versions the
+# lock file pins rather than whatever resolves today.
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+jobs:
+  test:
+    name: node --test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test


### PR DESCRIPTION
The same two workflows as #123, which targets `develop`. They are needed on `main` as well, and the reason is not symmetry.

## Why main needs them too

A hotfix is cut from `main`. When a hotfix pull request is opened, GitHub builds the merge commit from the hotfix branch and `main` — so if the workflows live only on `develop`, neither side has them, neither check ever runs, and with the checks required the hotfix cannot merge. To fix that you would have to switch protection off, at exactly the moment you are trying to ship an urgent fix.

Putting them on `main` now means every branch cut from it carries them.

## What they are

- `tests` — `npm ci` then `npm test`, Node 20, on every pull request and on pushes to `main` and `develop`.
- `guard main` — fails when a pull request into `main` comes from a branch that is neither `release/*` nor `hotfix/*`, with an error saying to go through `develop` and a release instead.

Neither is path-filtered: a required check that only runs sometimes cannot be satisfied the rest of the time.

## Checked

- `main` passes its own suite: 290 tests.
- The guard was proven on both paths before this: it failed a pull request from `test/guard-should-block` and passed one from `release/guard-test`. Both were closed unmerged.
- This pull request comes from `hotfix/*`, so the guard should pass on it.