### PR TITLE
hotfix/2.3.1 — put the test and guard workflows on main

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -25,14 +25,20 @@ jobs:
         env:
           SOURCE: ${{ github.head_ref }}
         run: |
-          case "$SOURCE" in
-            release/*|hotfix/*)
-              echo "Source branch '$SOURCE' may merge into main."
-              ;;
-            *)
-              echo "::error::'$SOURCE' cannot merge into main. Only release/* and hotfix/* branches may."
-              echo
-              echo "Merge this into develop instead, and let it reach main through a release."
-              exit 1
-              ;;
-          esac
+          # Named for the version they carry, so that every commit on main
+          # belongs to a release that can be pointed at. A hotfix raises the
+          # patch number, so its last component is never zero.
+          if printf '%s' "$SOURCE" | grep -Eq '^release/[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Release branch '$SOURCE' may merge into main."
+          elif printf '%s' "$SOURCE" | grep -Eq '^hotfix/[0-9]+\.[0-9]+\.[1-9][0-9]*$'; then
+            echo "Hotfix branch '$SOURCE' may merge into main."
+          else
+            echo "::error::'$SOURCE' cannot merge into main."
+            echo
+            echo "Only these may:"
+            echo "  release/x.y.z   a release cut from develop"
+            echo "  hotfix/x.y.z    a fix on top of main, with z of 1 or more"
+            echo
+            echo "Anything else belongs in develop, and reaches main through a release."
+            exit 1
+          fi

--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,38 @@
+# `main` is what production serves, and it is reached one of two ways: a
+# release cut from `develop`, or a hotfix. Anything else — a feature branch, a
+# chore, `develop` itself — belongs in `develop` first, so that what ships is
+# what was tested together.
+#
+# GitHub has no setting for "only these branches may open a pull request into
+# this one", so this stands in for it: a check that fails when the source
+# branch is not one of the two, made required on `main`.
+#
+# No path filter, and no condition on the job: a required check that does not
+# run cannot be satisfied, and the pull request would wait for a status that
+# never arrives.
+name: guard main
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  source-branch:
+    name: source branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only a release or a hotfix may merge into main
+        env:
+          SOURCE: ${{ github.head_ref }}
+        run: |
+          case "$SOURCE" in
+            release/*|hotfix/*)
+              echo "Source branch '$SOURCE' may merge into main."
+              ;;
+            *)
+              echo "::error::'$SOURCE' cannot merge into main. Only release/* and hotfix/* branches may."
+              echo
+              echo "Merge this into develop instead, and let it reach main through a release."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+# Runs the test suite on every pull request and on the branches releases are
+# cut from, so a change cannot reach either with the suite failing.
+#
+# `npm ci` rather than `npm install`: it installs exactly what
+# package-lock.json records, so a run here tests the dependency versions the
+# lock file pins rather than whatever resolves today.
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+jobs:
+  test:
+    name: node --test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ted-open-data",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "TED Open Data Service — SPARQL playground and notice browser for the European public procurement dataset",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
CI only. No change to the application.

## Why this is a hotfix rather than waiting for 2.4.0

A hotfix branch is cut from `main`. When its pull request is opened, GitHub builds the merge commit from that branch and `main` — so if the workflows live only on `develop`, neither side has them, neither check runs, and with the checks required the hotfix cannot merge. To get out you would have to switch protection off, at exactly the moment you are shipping an urgent fix.

Putting them on `main` now means every branch cut from it carries them.

## Why the version moves

So that every commit on `main` belongs to a release that can be pointed at. Without a bump, two different `main` commits would both call themselves 2.3.0 and the version would stop identifying what is deployed.

There are no release notes to write: this changes nothing a user can observe.

## What lands

- `tests` — `npm ci` then `npm test`, Node 20, on every pull request and on pushes to `main` and `develop`.
- `guard main` — a pull request into `main` must come from `release/x.y.z` or `hotfix/x.y.z`, the latter with a patch of 1 or more. Anything else fails with a message saying to go through `develop`.

Neither is path-filtered: a required check that only runs sometimes cannot be satisfied the rest of the time.

## Checked

- `main` passes its own suite: 290 tests.
- The guard was proven on both paths before being tightened — it failed a pull request from `test/guard-should-block` and passed one from `release/guard-test`, both closed unmerged.
- The tightened rules were exercised over the shapes that matter: `release/2.4.0` and `hotfix/2.3.1` pass; `hotfix/2.3.0`, `release/2.4`, `release/2.4.0-rc1`, `develop` and a plain feature branch all fail.
- This pull request comes from `hotfix/2.3.1`, so it should pass its own guard.