### PR TITLE
chore: back-merge 2.3.1 into develop

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -25,14 +25,20 @@ jobs:
         env:
           SOURCE: ${{ github.head_ref }}
         run: |
-          case "$SOURCE" in
-            release/*|hotfix/*)
-              echo "Source branch '$SOURCE' may merge into main."
-              ;;
-            *)
-              echo "::error::'$SOURCE' cannot merge into main. Only release/* and hotfix/* branches may."
-              echo
-              echo "Merge this into develop instead, and let it reach main through a release."
-              exit 1
-              ;;
-          esac
+          # Named for the version they carry, so that every commit on main
+          # belongs to a release that can be pointed at. A hotfix raises the
+          # patch number, so its last component is never zero.
+          if printf '%s' "$SOURCE" | grep -Eq '^release/[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Release branch '$SOURCE' may merge into main."
+          elif printf '%s' "$SOURCE" | grep -Eq '^hotfix/[0-9]+\.[0-9]+\.[1-9][0-9]*$'; then
+            echo "Hotfix branch '$SOURCE' may merge into main."
+          else
+            echo "::error::'$SOURCE' cannot merge into main."
+            echo
+            echo "Only these may:"
+            echo "  release/x.y.z   a release cut from develop"
+            echo "  hotfix/x.y.z    a fix on top of main, with z of 1 or more"
+            echo
+            echo "Anything else belongs in develop, and reaches main through a release."
+            exit 1
+          fi

--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,38 @@
+# `main` is what production serves, and it is reached one of two ways: a
+# release cut from `develop`, or a hotfix. Anything else — a feature branch, a
+# chore, `develop` itself — belongs in `develop` first, so that what ships is
+# what was tested together.
+#
+# GitHub has no setting for "only these branches may open a pull request into
+# this one", so this stands in for it: a check that fails when the source
+# branch is not one of the two, made required on `main`.
+#
+# No path filter, and no condition on the job: a required check that does not
+# run cannot be satisfied, and the pull request would wait for a status that
+# never arrives.
+name: guard main
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  source-branch:
+    name: source branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Only a release or a hotfix may merge into main
+        env:
+          SOURCE: ${{ github.head_ref }}
+        run: |
+          case "$SOURCE" in
+            release/*|hotfix/*)
+              echo "Source branch '$SOURCE' may merge into main."
+              ;;
+            *)
+              echo "::error::'$SOURCE' cannot merge into main. Only release/* and hotfix/* branches may."
+              echo
+              echo "Merge this into develop instead, and let it reach main through a release."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+# Runs the test suite on every pull request and on the branches releases are
+# cut from, so a change cannot reach either with the suite failing.
+#
+# `npm ci` rather than `npm install`: it installs exactly what
+# package-lock.json records, so a run here tests the dependency versions the
+# lock file pins rather than whatever resolves today.
+name: tests
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+jobs:
+  test:
+    name: node --test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ted-open-data",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "TED Open Data Service — SPARQL playground and notice browser for the European public procurement dataset",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The hotfix that put the CI workflows on `main` (#127), brought back so `develop` has them too and the next release does not undo them.

## The one conflict

`package.json`. `main` moved to 2.3.1, `develop` is at 2.4.0-SNAPSHOT. Resolved in favour of `develop`: it is ahead, and the release in progress is 2.4.0.

Everything else merged cleanly.

## What arrives

- `.github/workflows/test.yml`
- `.github/workflows/guard-main.yml`, in its tightened form — `release/x.y.z` and `hotfix/x.y.z` with a patch of 1 or more, rather than the looser prefix match that was on #123.

## Supersedes #123

#123 carried the same workflows to `develop` directly, with the looser guard. This replaces it, so `develop` never sees a version that would have accepted a branch called `hotfix/ci-guards`.

## Checked

- 321 tests pass on the merged tree.
- Both workflows are present, and the guard is the tightened one.