### PR TITLE
What's new beside the help text, not on top of it (rework of #112 and #114)

### DIFF
--- a/index.html
+++ b/index.html
@@ -707,6 +707,112 @@
                 <div class="row">
                     <!-- Left Column - Help Content -->
                     <div class="col-lg-8">
+                        <h2>What's new</h2>
+                        <div class="accordion mb-4" id="release-notes-accordion">
+                            <!-- 2.4.0 — expanded by default -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header" id="release-2-4-0-header">
+                                    <button class="accordion-button" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-4-0" aria-expanded="true" aria-controls="release-2-4-0">
+                                        Version 2.4.0 — August 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-4-0" class="accordion-collapse collapse show"
+                                     aria-labelledby="release-2-4-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>Query Library form mode:</b> Parameterised queries now show input fields (date pickers, month/year selectors, text inputs) so non-technical users can run queries without editing SPARQL.</li>
+                                            <li><b>Copy property path:</b> Hover any nested node in the tree view to reveal a clipboard icon. Clicking it copies a ready-to-use SPARQL triple pattern snippet.</li>
+                                            <li><b>Ontology-aligned badge labels:</b> Tree view badges now show ePO ontology class names (e.g. "Contract") instead of mapping-specific names (e.g. "SettledContract").</li>
+                                            <li><b>Date validation:</b> Invalid dates in the SPARQL editor are flagged with red underline and the Run button is disabled. The form validates date ranges (start ≤ end).</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- 2.3.0 — collapsed -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header" id="release-2-3-0-header">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-3-0" aria-expanded="false" aria-controls="release-2-3-0">
+                                        Version 2.3.0 — July 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-3-0" class="accordion-collapse collapse"
+                                     aria-labelledby="release-2-3-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>Chart visualization:</b> SELECT query results can now be displayed as interactive charts (bar, line, pie, scatter) via a Table/Chart toggle when results are chartable.</li>
+                                            <li><b>Exchange rate snippet:</b> Type <code>currency</code> in the editor to insert a currency conversion lookup table with EUR exchange rates, refreshed automatically from InforEuro.</li>
+                                            <li><b>Clickable URLs in results:</b> Web URLs in SELECT result tables are now rendered as clickable links.</li>
+                                            <li><b>Query execution time:</b> Elapsed time is displayed in the results toolbar after each query runs.</li>
+                                            <li><b>Not-found notice tracking:</b> Notices that don't exist are kept in search history with a "not found" badge, so you know which numbers you already tried.</li>
+                                            <li><b>ePO v3 + v4 autocomplete:</b> Editor now recognises terms from both Standard Forms (v3) and eForms (v4) ontology versions.</li>
+                                            <li><b>Guided tours:</b> Each tab has a play icon that launches an interactive walkthrough.</li>
+                                            <li><b>Query Library improvements:</b> "Try this query" and "Customise" buttons, copy SPARQL to clipboard, error handling with retry.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- 2.2.0 — collapsed -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header" id="release-2-2-0-header">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-2-0" aria-expanded="false" aria-controls="release-2-2-0">
+                                        Version 2.2.0 — May 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-2-0" class="accordion-collapse collapse"
+                                     aria-labelledby="release-2-2-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>ePO 3 (Standard Forms) support:</b> The Inspect tab now works for older notices published under Standard Forms, not just eForms. A fallback query finds notices by their identifier value when the primary lookup returns no results.</li>
+                                            <li><b>22 new SPARQL queries added:</b> New categories Stats, Federated queries and Contracts created and 22 new SPARQL queries have been added.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- 2.1.0 — collapsed -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header" id="release-2-1-0-header">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-1-0" aria-expanded="false" aria-controls="release-2-1-0">
+                                        Version 2.1.0 — April 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-1-0" class="accordion-collapse collapse"
+                                     aria-labelledby="release-2-1-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>Search in tree:</b> A search bar above the tree view lets you find specific properties or values within a notice. Type at least 3 characters and use the arrow buttons to jump between matches.</li>
+                                            <li><b>SPARQL reference card:</b> Click the code icon on any tree resource to see its PREFIX declaration, prefixed name, and IRI — ready to copy into your SPARQL query.</li>
+                                            <li><b>Meaningful Turtle prefixes:</b> The Turtle view now uses human-readable namespace prefixes (e.g. <code>epo:</code>) instead of auto-generated ones.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- 2.0.0 — collapsed -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header" id="release-2-0-0-header">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-0-0" aria-expanded="false" aria-controls="release-2-0-0">
+                                        Version 2.0.0 — March 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-0-0" class="accordion-collapse collapse"
+                                     aria-labelledby="release-2-0-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>Inspect tab:</b> Look up any notice by publication number and explore its full RDF graph as an interactive tree, raw Turtle, or backlinks view.</li>
+                                            <li><b>Procedure timeline:</b> See all notices belonging to the same procurement procedure, ordered chronologically with colour-coded cards (green for originals, yellow for amendments).</li>
+                                            <li><b>Share and download:</b> Copy a shareable URL that reproduces your exact view, or download the RDF data as Turtle, RDF/XML, or N-Triples.</li>
+                                            <li><b>Home tab:</b> A carousel introduction with quick-start CTAs for each workflow.</li>
+                                            <li><b>Redesigned layout:</b> EU institutional header, sticky navigation, and a unified tab structure (Inspect, Explore, Customize).</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
                         <h2>Help</h2>
                         <p>
                             The TED Open Data Service lets you explore the entire collection of public procurement data

--- a/index.html
+++ b/index.html
@@ -707,112 +707,6 @@
                 <div class="row">
                     <!-- Left Column - Help Content -->
                     <div class="col-lg-8">
-                        <h2>What's new</h2>
-                        <div class="accordion mb-4" id="release-notes-accordion">
-                            <!-- 2.4.0 — expanded by default -->
-                            <div class="accordion-item">
-                                <h3 class="accordion-header" id="release-2-4-0-header">
-                                    <button class="accordion-button" type="button" data-bs-toggle="collapse"
-                                            data-bs-target="#release-2-4-0" aria-expanded="true" aria-controls="release-2-4-0">
-                                        August 2026
-                                    </button>
-                                </h3>
-                                <div id="release-2-4-0" class="accordion-collapse collapse show"
-                                     aria-labelledby="release-2-4-0-header" data-bs-parent="#release-notes-accordion">
-                                    <div class="accordion-body">
-                                        <ul>
-                                            <li><b>Query Library form mode:</b> Parameterised queries now show input fields (date pickers, month/year selectors, text inputs) so non-technical users can run queries without editing SPARQL.</li>
-                                            <li><b>Copy property path:</b> Hover any nested node in the tree view to reveal a clipboard icon. Clicking it copies a ready-to-use SPARQL triple pattern snippet.</li>
-                                            <li><b>Ontology-aligned badge labels:</b> Tree view badges now show ePO ontology class names (e.g. "Contract") instead of mapping-specific names (e.g. "SettledContract").</li>
-                                            <li><b>Date validation:</b> Invalid dates in the SPARQL editor are flagged with red underline and the Run button is disabled. The form validates date ranges (start ≤ end).</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- 2.3.0 — collapsed -->
-                            <div class="accordion-item">
-                                <h3 class="accordion-header" id="release-2-3-0-header">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-                                            data-bs-target="#release-2-3-0" aria-expanded="false" aria-controls="release-2-3-0">
-                                        July 2026
-                                    </button>
-                                </h3>
-                                <div id="release-2-3-0" class="accordion-collapse collapse"
-                                     aria-labelledby="release-2-3-0-header" data-bs-parent="#release-notes-accordion">
-                                    <div class="accordion-body">
-                                        <ul>
-                                            <li><b>Chart visualization:</b> SELECT query results can now be displayed as interactive charts (bar, line, pie, scatter) via a Table/Chart toggle when results are chartable.</li>
-                                            <li><b>Exchange rate snippet:</b> Type <code>currency</code> in the editor to insert a currency conversion lookup table with EUR exchange rates, refreshed automatically from InforEuro.</li>
-                                            <li><b>Clickable URLs in results:</b> Web URLs in SELECT result tables are now rendered as clickable links.</li>
-                                            <li><b>Query execution time:</b> Elapsed time is displayed in the results toolbar after each query runs.</li>
-                                            <li><b>Not-found notice tracking:</b> Notices that don't exist are kept in search history with a "not found" badge, so you know which numbers you already tried.</li>
-                                            <li><b>ePO v3 + v4 autocomplete:</b> Editor now recognises terms from both Standard Forms (v3) and eForms (v4) ontology versions.</li>
-                                            <li><b>Guided tours:</b> Each tab has a play icon that launches an interactive walkthrough.</li>
-                                            <li><b>Query Library improvements:</b> "Try this query" and "Customise" buttons, copy SPARQL to clipboard, error handling with retry.</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- 2.2.0 — collapsed -->
-                            <div class="accordion-item">
-                                <h3 class="accordion-header" id="release-2-2-0-header">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-                                            data-bs-target="#release-2-2-0" aria-expanded="false" aria-controls="release-2-2-0">
-                                        May 2026
-                                    </button>
-                                </h3>
-                                <div id="release-2-2-0" class="accordion-collapse collapse"
-                                     aria-labelledby="release-2-2-0-header" data-bs-parent="#release-notes-accordion">
-                                    <div class="accordion-body">
-                                        <ul>
-                                            <li><b>ePO 3 (Standard Forms) support:</b> The Inspect tab now works for older notices published under Standard Forms, not just eForms. A fallback query finds notices by their identifier value when the primary lookup returns no results.</li>
-                                            <li><b>22 new SPARQL queries added:</b> New categories Stats, Federated queries and Contracts created and 22 new SPARQL queries have been added.</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- 2.1.0 — collapsed -->
-                            <div class="accordion-item">
-                                <h3 class="accordion-header" id="release-2-1-0-header">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-                                            data-bs-target="#release-2-1-0" aria-expanded="false" aria-controls="release-2-1-0">
-                                        April 2026
-                                    </button>
-                                </h3>
-                                <div id="release-2-1-0" class="accordion-collapse collapse"
-                                     aria-labelledby="release-2-1-0-header" data-bs-parent="#release-notes-accordion">
-                                    <div class="accordion-body">
-                                        <ul>
-                                            <li><b>Search in tree:</b> A search bar above the tree view lets you find specific properties or values within a notice. Type at least 3 characters and use the arrow buttons to jump between matches.</li>
-                                            <li><b>SPARQL reference card:</b> Click the code icon on any tree resource to see its PREFIX declaration, prefixed name, and IRI — ready to copy into your SPARQL query.</li>
-                                            <li><b>Meaningful Turtle prefixes:</b> The Turtle view now uses human-readable namespace prefixes (e.g. <code>epo:</code>) instead of auto-generated ones.</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                            <!-- 2.0.0 — collapsed -->
-                            <div class="accordion-item">
-                                <h3 class="accordion-header" id="release-2-0-0-header">
-                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
-                                            data-bs-target="#release-2-0-0" aria-expanded="false" aria-controls="release-2-0-0">
-                                        March 2026
-                                    </button>
-                                </h3>
-                                <div id="release-2-0-0" class="accordion-collapse collapse"
-                                     aria-labelledby="release-2-0-0-header" data-bs-parent="#release-notes-accordion">
-                                    <div class="accordion-body">
-                                        <ul>
-                                            <li><b>Inspect tab:</b> Look up any notice by publication number and explore its full RDF graph as an interactive tree, raw Turtle, or backlinks view.</li>
-                                            <li><b>Procedure timeline:</b> See all notices belonging to the same procurement procedure, ordered chronologically with colour-coded cards (green for originals, yellow for amendments).</li>
-                                            <li><b>Share and download:</b> Copy a shareable URL that reproduces your exact view, or download the RDF data as Turtle, RDF/XML, or N-Triples.</li>
-                                            <li><b>Home tab:</b> A carousel introduction with quick-start CTAs for each workflow.</li>
-                                            <li><b>Redesigned layout:</b> EU institutional header, sticky navigation, and a unified tab structure (Inspect, Explore, Customize).</li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
                         <h2>Help</h2>
                         <p>
                             The TED Open Data Service lets you explore the entire collection of public procurement data
@@ -910,10 +804,132 @@
                         </p>
                     </div>
 
-                    <!-- Right Column - Components -->
+                    <!-- Right Column - release notes, then the components list.
+                         Both are reference material; neither competes with the
+                         help text beside them. -->
                     <div class="col-lg-4">
+                        <!-- Carried in a card, like the components list below
+                             it: the column holds two reference panels rather
+                             than a heading competing with the one beside it. -->
+                        <!-- overflow-hidden: the accordion inside runs to the
+                             card's edge, and its last item has square corners
+                             that would otherwise cover the card's rounded ones. -->
+                        <div class="card mb-4 overflow-hidden">
+                            <div class="card-header">
+                                <!-- An h2 set to look like an h5: the releases
+                                     below it are h3, and a parent heading must
+                                     not sit at a lower level than its children. -->
+                                <h2 class="card-title h5 mb-0">What's new</h2>
+                            </div>
+                            <div class="card-body p-0">
+                        <div class="accordion accordion-flush" id="release-notes-accordion">
+                            <!-- 2.4.0 — expanded by default -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header ted-accordion-header" id="release-2-4-0-header">
+                                    <button class="accordion-button" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-4-0" aria-expanded="true" aria-controls="release-2-4-0">
+                                        August 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-4-0" class="accordion-collapse collapse show"
+                                     aria-labelledby="release-2-4-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>Connect your app</b>The "Copy endpoint URL" button is now "Connect your app". It offers the query link in JSON, CSV, TSV or XML (e.g. for Excel or Power BI), the raw SPARQL text, and the same request as a cURL, wget or PowerShell command.</li>
+                                            <li><b>Copy property path</b>Every card and row in the tree view now has an actions menu. It copies a ready-to-use SPARQL triple pattern snippet, copies the value, or opens the SPARQL reference card.</li>
+                                            <li><b>Ontology-aligned badge labels</b>Tree view badges now show ePO ontology class names (e.g. "Contract") instead of mapping-specific names (e.g. "SettledContract").</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- 2.3.0 — collapsed -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header ted-accordion-header" id="release-2-3-0-header">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-3-0" aria-expanded="false" aria-controls="release-2-3-0">
+                                        July 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-3-0" class="accordion-collapse collapse"
+                                     aria-labelledby="release-2-3-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>Chart visualization</b>SELECT query results can now be displayed as interactive charts (bar, line, pie, scatter) via a Table/Chart toggle when results are chartable.</li>
+                                            <li><b>Exchange rate snippet</b>Type <code>currency</code> in the editor to insert a currency conversion lookup table with EUR exchange rates, refreshed automatically from InforEuro.</li>
+                                            <li><b>Clickable URLs in results</b>Web URLs in SELECT result tables are now rendered as clickable links.</li>
+                                            <li><b>Query execution time</b>Elapsed time is displayed in the results toolbar after each query runs.</li>
+                                            <li><b>Not-found notice tracking</b>Notices that don't exist are kept in search history with a "not found" badge, so you know which numbers you already tried.</li>
+                                            <li><b>ePO v3 + v4 autocomplete</b>Editor now recognises terms from both Standard Forms (v3) and eForms (v4) ontology versions.</li>
+                                            <li><b>Guided tours</b>Each tab has a play icon that launches an interactive walkthrough.</li>
+                                            <li><b>Query Library improvements</b>"Try this query" and "Customise" buttons, copy SPARQL to clipboard, error handling with retry.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- 2.2.0 — collapsed -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header ted-accordion-header" id="release-2-2-0-header">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-2-0" aria-expanded="false" aria-controls="release-2-2-0">
+                                        May 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-2-0" class="accordion-collapse collapse"
+                                     aria-labelledby="release-2-2-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>ePO 3 (Standard Forms) support</b>The Inspect tab now works for older notices published under Standard Forms, not just eForms. A fallback query finds notices by their identifier value when the primary lookup returns no results.</li>
+                                            <li><b>22 new SPARQL queries added</b>New categories Stats, Federated queries and Contracts created and 22 new SPARQL queries have been added.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- 2.1.0 — collapsed -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header ted-accordion-header" id="release-2-1-0-header">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-1-0" aria-expanded="false" aria-controls="release-2-1-0">
+                                        April 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-1-0" class="accordion-collapse collapse"
+                                     aria-labelledby="release-2-1-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>Search in tree</b>A search bar above the tree view lets you find specific properties or values within a notice. Type at least 3 characters and use the arrow buttons to jump between matches.</li>
+                                            <li><b>SPARQL reference card</b>Click the code icon on any tree resource to see its PREFIX declaration, prefixed name, and IRI — ready to copy into your SPARQL query.</li>
+                                            <li><b>Meaningful Turtle prefixes</b>The Turtle view now uses human-readable namespace prefixes (e.g. <code>epo:</code>) instead of auto-generated ones.</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- 2.0.0 — collapsed -->
+                            <div class="accordion-item">
+                                <h3 class="accordion-header ted-accordion-header" id="release-2-0-0-header">
+                                    <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
+                                            data-bs-target="#release-2-0-0" aria-expanded="false" aria-controls="release-2-0-0">
+                                        March 2026
+                                    </button>
+                                </h3>
+                                <div id="release-2-0-0" class="accordion-collapse collapse"
+                                     aria-labelledby="release-2-0-0-header" data-bs-parent="#release-notes-accordion">
+                                    <div class="accordion-body">
+                                        <ul>
+                                            <li><b>Inspect tab</b>Look up any notice by publication number and explore its full RDF graph as an interactive tree, raw Turtle, or backlinks view.</li>
+                                            <li><b>Procedure timeline</b>See all notices belonging to the same procurement procedure, ordered chronologically with colour-coded cards (green for originals, yellow for amendments).</li>
+                                            <li><b>Share and download</b>Copy a shareable URL that reproduces your exact view, or download the RDF data as Turtle, RDF/XML, or N-Triples.</li>
+                                            <li><b>Home tab</b>A carousel introduction with quick-start CTAs for each workflow.</li>
+                                            <li><b>Redesigned layout</b>EU institutional header, sticky navigation, and a unified tab structure (Inspect, Explore, Customize).</li>
+                                        </ul>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                            </div>
+                        </div>
+
                         <!-- Third-Party Components -->
-                        <div class="card">
+                        <div class="card" id="third-party-components">
                             <div class="card-header">
                                 <h5 class="card-title mb-0">Third-Party Components</h5>
                             </div>

--- a/index.html
+++ b/index.html
@@ -714,7 +714,7 @@
                                 <h3 class="accordion-header" id="release-2-4-0-header">
                                     <button class="accordion-button" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-4-0" aria-expanded="true" aria-controls="release-2-4-0">
-                                        Version 2.4.0 — August 2026
+                                        August 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-4-0" class="accordion-collapse collapse show"
@@ -734,7 +734,7 @@
                                 <h3 class="accordion-header" id="release-2-3-0-header">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-3-0" aria-expanded="false" aria-controls="release-2-3-0">
-                                        Version 2.3.0 — July 2026
+                                        July 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-3-0" class="accordion-collapse collapse"
@@ -758,7 +758,7 @@
                                 <h3 class="accordion-header" id="release-2-2-0-header">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-2-0" aria-expanded="false" aria-controls="release-2-2-0">
-                                        Version 2.2.0 — May 2026
+                                        May 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-2-0" class="accordion-collapse collapse"
@@ -776,7 +776,7 @@
                                 <h3 class="accordion-header" id="release-2-1-0-header">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-1-0" aria-expanded="false" aria-controls="release-2-1-0">
-                                        Version 2.1.0 — April 2026
+                                        April 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-1-0" class="accordion-collapse collapse"
@@ -795,7 +795,7 @@
                                 <h3 class="accordion-header" id="release-2-0-0-header">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-0-0" aria-expanded="false" aria-controls="release-2-0-0">
-                                        Version 2.0.0 — March 2026
+                                        March 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-0-0" class="accordion-collapse collapse"

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -289,11 +289,18 @@ main {
     font-weight: 500;
 }
 
-/* Third-Party Components Card */
+/* The reference cards in the Help tab's right column. Their headers take
+   eu-blue-10, the accent the accordion inside one of them already uses, so
+   the column reads in one colour rather than two. */
 #help .card .card-header {
-    background-color: var(--light-background-color);
-    color: var(--ted-primary);
+    background-color: var(--ted-blue-10);
     border-bottom: 1px solid var(--border-color);
+}
+
+/* The Help tab makes every heading green. A card title sits on a blue ground
+   here, so it is set apart from that rule rather than inheriting it. */
+#help .card .card-header .card-title {
+    color: var(--ted-text); /* gray-100 */
 }
 
 /* Explorer-port card headers should NOT inherit the global
@@ -862,12 +869,49 @@ main {
     max-height: calc(100vh - var(--header-total-height, 251px) - 80px);
 }
 
-.query-library-accordion-header {
+/* Accordions in this application look alike wherever they appear: the query
+   library's categories and the release notes both use this. */
+.ted-accordion-header {
     margin-bottom: 0;
 }
-.query-library-accordion-header .accordion-button:not(.collapsed) {
-    background-color: var(--ted-blue-5); /* eu-blue-5 — selected category only */
+.ted-accordion-header .accordion-button:not(.collapsed) {
+    background-color: var(--ted-blue-5); /* eu-blue-5 — the open item only */
     box-shadow: none;
+}
+
+/* The release notes share the Help tab's right column with the third-party
+   components card, so they are sized to it rather than to the body text of
+   the column beside them. 0.875rem is the <small> that card is written in. */
+/* Set like the components card beneath: the name of the thing at body size in
+   body colour, what it does smaller and muted under it. */
+#release-notes-accordion .accordion-body {
+    font-size: 0.875rem;
+    color: var(--ted-text-muted);
+}
+
+/* Entries are set like the components card beneath: no bullets, and the name
+   of the thing on its own line above what it does. */
+#release-notes-accordion .accordion-body ul {
+    list-style: none;
+    padding-left: 0;
+    margin-bottom: 0;
+}
+
+#release-notes-accordion .accordion-body li + li {
+    margin-top: 0.75rem;
+}
+
+#release-notes-accordion .accordion-body b {
+    display: block;
+    font-size: 1rem;
+    color: var(--bs-body-color);
+}
+
+/* The two panels in this column group their contents the same way, so their
+   group headings are set alike — an h6 is 500 where an accordion button is
+   400, and that was the only difference. */
+#third-party-components .card-body h6 {
+    font-weight: 400;
 }
 
 /* ─────────────────────────────────────────────────────────────────

--- a/src/js/QueryLibrary.js
+++ b/src/js/QueryLibrary.js
@@ -156,7 +156,7 @@ export class QueryLibrary {
         categoryItem.className = 'accordion-item';
 
         const header = document.createElement('h2');
-        header.className = 'query-library-accordion-header';
+        header.className = 'ted-accordion-header';
         header.id = `${categoryId}-header`;
 
         const isFirst = categoryCounter === 1;


### PR DESCRIPTION
Re-implementation of #112 and #114 on the reworked base, for issue #106.

This branch sits on `rework/115-query-source` (PR #122) and is the last of the batch. It contains @Anoop-Variyan's two commits unchanged, with one commit on top.

## Where it was

The release notes were a full-width accordion at the top of the Help tab, above the help text itself. The Help tab is already dense, and the notes are reference material — putting them first pushed the thing people came for below the fold.

## Where they are now

In the right column, as a card, above the existing Third-Party Components card. Both are reference; neither competes with the help text beside them.

The two panels are set alike: the release entries carry no bullets, the name of each feature sits on its own line above what it does, and the sizes and colours match the components card — 1rem in body colour for the name, 0.875rem muted for the description. Group headings in both are at the same weight. The card headers take eu-blue-10, one step up from the eu-blue-5 the accordion inside uses, so the column reads in one colour.

The accordion's own styling now comes from `.ted-accordion-header`, shared with the query library's categories rather than copied from them, so the two cannot drift apart.

## The content

Two of the four entries for 2.4.0 described features that are not in this release:

- **Query Library form mode** — the feature was dropped.
- **Date validation** — its date linter came from the same work, and is not in this base either.

Two were kept, edited only where they had stopped being true:

- **Copy property path** — the hover clipboard icon it describes was replaced by the actions menu (#118). The label and Anoop's phrase for what it produces are unchanged.
- **Ontology-aligned badge labels** — restored word for word. It was already accurate for what #119 does.

One was added, from the line Anoop wrote for it in #113 and which was dropped when that branch was reworked:

- **Connect your app** — framed as what it is, an improvement to a button that already existed rather than a new feature.

Button names are in quotes, as Anoop writes them in the 2.3.0 entry.

## From review

- **A card titled `h5` contained `h3` headings** — a parent heading below its own children in the outline. It is an `h2` with the `h5` visual class now, so it looks the same and reads correctly to a screen reader.
- The card clips its children to its radius: the accordion runs to the card's edge, and its last item's square corners covered the card's rounded ones.

## Tests

526, unchanged. Nothing here is testable beyond what already is — the change is markup and styling.

## Known limitations

- **It grows.** Five releases fit in that column; twelve will not, and nothing decides what falls off. The underlying question — that a permanent changelog and a transient "what's new" are two different things — is not settled here. A `CHANGELOG.md` and an announcement per release in Discussions would carry the permanent record, leaving only the current release in the application.
- **The green and blue are two conventions meeting.** The Help tab makes every heading green; these cards sit on blue. That belongs to a styling pass against the style guide, which this application predates.
- **Below 992px** the column stacks after the whole help article, so the notes come last. Deciding otherwise means separating the two panels so they can move independently, which is more restructuring than this carries.
